### PR TITLE
Added support for Travis CI (Important: update to maven 3.1.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,13 @@
 language: java
+before_install:
+  - sudo apt-get update -qq
+  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+  - cd ..
+  - wget http://dl.google.com/android/android-sdk_r22.3-linux.tgz
+  - tar -vzxf android-sdk_r22.3-linux.tgz
+  - export ANDROID_HOME=`pwd`/android-sdk-linux
+  - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+  # only update the sdk for the tools and platform-tools (1,2) and whatever api level
+  # you are building for android (run "android list sdk" to get the full list. 9 = 2.3.3 or API level 10
+  - echo y | android update sdk --filter 1,2,8 --no-ui --force
+  - cd ead

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<gdx.version>1.0-SNAPSHOT</gdx.version>
 		<android.version>4.1.1.4</android.version>
-		<android.maven.version>3.6.0</android.maven.version>
+		<android.maven.version>3.8.1</android.maven.version>
 		<gwt.version>2.5.0</gwt.version>
 		<gwt.maven.version>2.5.0</gwt.maven.version>
 	</properties>


### PR DESCRIPTION
I added the travis webhook to aumotatically test the master branch and pull requests. However, Travis works with maven 3.1.1, so I also updated the android maven plugin version to work with 3.1.1.

So, with this update, android compilation fails with maven 3.0.5. From now on, eadventure requires maven 3.1.1+ (I updated the info in the wiki)
