### PR TITLE
A couple of improvements to Video VLC implementation (desktop). This com...

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/Engine.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/Engine.java
@@ -41,6 +41,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
+import es.eucm.ead.engine.actions.AbstractVideoAction;
 import es.eucm.ead.engine.triggers.TouchSource;
 import es.eucm.ead.engine.io.SchemaIO;
 import es.eucm.ead.engine.scene.SceneManager;
@@ -152,6 +153,6 @@ public class Engine implements ApplicationListener {
 
 	@Override
 	public void dispose() {
-	}
+    }
 
 }

--- a/engine/core/src/main/java/es/eucm/ead/engine/actions/AbstractVideoAction.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/actions/AbstractVideoAction.java
@@ -75,4 +75,12 @@ public abstract class AbstractVideoAction extends AbstractAction<Video> {
 	public void end() {
 		done = true;
 	}
+
+    /**
+     * This method should be overwriten by implementation subclases, if the subclass makes use of any native resources that need to be released when exit() or dispose() are invoked.
+     * For example, VLC-based implementations of VideoAction for desktop should overwrite this. In contrast, Android implementations may not need it.
+     */
+    public static void release(){
+
+    }
 }

--- a/engine/desktop/src/main/java/es/eucm/ead/engine/EngineDesktop.java
+++ b/engine/desktop/src/main/java/es/eucm/ead/engine/EngineDesktop.java
@@ -36,8 +36,15 @@
  */
 package es.eucm.ead.engine;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
 import com.badlogic.gdx.backends.lwjgl.LwjglFrame;
+import es.eucm.ead.engine.actions.VideoAction;
+
+import javax.swing.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 
 public class EngineDesktop {
 	public static LwjglFrame frame;
@@ -62,7 +69,32 @@ public class EngineDesktop {
 		config.height = height;
 		config.forceExit = true;
 		frame = new LwjglFrame(new Engine(gameUri), config);
+        frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+        frame.addWindowListener(new WindowAdapter(){
+
+           @Override
+            public void windowClosing(WindowEvent e) {
+                doDispose();
+            }
+
+        });
 		frame.setLocationRelativeTo(null);
-		frame.setVisible(true);
-	}
+        SwingUtilities.invokeLater(new Runnable(){
+
+            @Override
+            public void run() {
+                frame.setVisible(true);
+            }
+        });
+    }
+
+    private void doDispose(){
+        Gdx.app.log("EngineDesktop", "Cleaning resources up...");
+
+        // Just to make sure that Video Player resources are released, if any
+        VideoAction.release();
+
+        Gdx.app.log("EngineDesktop", "Invoking Gdx.app.exit");
+        Gdx.app.exit();
+    }
 }

--- a/engine/desktop/src/main/java/es/eucm/ead/engine/actions/VideoAction.java
+++ b/engine/desktop/src/main/java/es/eucm/ead/engine/actions/VideoAction.java
@@ -59,4 +59,18 @@ public class VideoAction extends AbstractVideoAction {
 					+ "' doesn't exist.");
 		}
 	}
+
+    /**
+     * Makes sure that if vlc was initialized, then all native resources it loaded are disposed.
+     * Should be invoked only as a consequence of a dispose() or exit()
+     * See VLCPlayer.release for more details.
+     */
+    public static void release(){
+        if (vlcPlayer!=null){
+            Gdx.app.log("VideoAction", "The VLC Component was created. Trying to release its resources (invoking VLCPLayer.release()...");
+            vlcPlayer.release();
+        } else{
+            Gdx.app.log("VideoAction", "The VLC Component was not created. No resources to release");
+        }
+    }
 }

--- a/engine/desktop/src/main/java/es/eucm/ead/engine/actions/video/VLCPlayer.java
+++ b/engine/desktop/src/main/java/es/eucm/ead/engine/actions/video/VLCPlayer.java
@@ -82,7 +82,7 @@ public class VLCPlayer {
 		try {
 			System.setProperty("jna.nosys", "true");
 			mediaPlayerComponent = new EmbeddedMediaPlayerComponent();
-			videoSurface = mediaPlayerComponent.getVideoSurface();
+            videoSurface = mediaPlayerComponent.getVideoSurface();
 			mediaPlayer = mediaPlayerComponent.getMediaPlayer();
 			gameSurface = EngineDesktop.frame.getLwjglCanvas().getCanvas();
 
@@ -218,4 +218,17 @@ public class VLCPlayer {
 		}
 		return destiny;
 	}
+
+    /**
+     * This method makes sure all resources initialized by VLC (e.g. native libraries loaded like OpenAL, audio and video streams, etc.), are cleaned up properly.
+     * This method should ONLY be invoked by VideoAction, who controls video play, as a reaction to exit() or dispose() being invoked
+     */
+    public void release(){
+        if (mediaPlayer!=null){
+            Gdx.app.log("VLCPlayer", "The Media Player Component was created. Trying to release its resources...");
+            mediaPlayerComponent.release();
+        } else{
+            Gdx.app.log("VLCPlayer", "The Media Player Component was not created. Nothing to cleanup then");
+        }
+    }
 }

--- a/engine/desktop/src/test/java/es/eucm/ead/engine/demos/VideoDemo.java
+++ b/engine/desktop/src/test/java/es/eucm/ead/engine/demos/VideoDemo.java
@@ -8,7 +8,8 @@ public class VideoDemo {
 
 	public static void main(String args[]) {
 		EngineDesktop engine = new EngineDesktop(1066, 600);
-		engine.run("@videodemo");
+
+        engine.run("@videodemo");
 		Gdx.app.setLogLevel(Application.LOG_DEBUG);
 	}
 }


### PR DESCRIPTION
This commit is related to issue #32 , although it does not fix it apparently (the same "AL lib: (EE) alc_cleanup: 1 device not closed" message still appears). However, this commit makes a couple of improvements to VLC video:
- EngineDesktop has been modified to ensure some good cleaning when the application is closed:
  - It will try to release VLC resources, if created
  - Invokes Gdx.app.exit, instead of calling System.exit directly
    Engine.dispose() remains untouched since all these operations seem to be platform-dependent. however, we may want to think a little about setting up a proper dispose protocol (I guess nothing has been really implemented yet)
- I've also wrapped frame.setVisible(true) in EngineDesktop.run() within a SwingUtilities.invokeLater, because in my computer most of the times the Window did not actually show up! This solves that random behaviour.
