### PR TITLE
VariableDefs read correctly from json; "lang" variable for game i18n

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/I18N.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/I18N.java
@@ -127,7 +127,7 @@ public class I18N {
 				overlayMessages("_" + lang);
 			}
 			Gdx.app.log("I18N", "Loaded all messages (" + messages.size()
-					+ " total); lang is " + lang);
+					+ " total); lang is '" + lang + "'");
 		} catch (IOException e) {
 			Gdx.app.error("I18N", "Error loading messages", e);
 		}
@@ -156,7 +156,14 @@ public class I18N {
 	private void load(FileHandle fileHandle, Map<String, String> map) {
 		String[] lines = fileHandle.readString().split("\n");
 		for (String line : lines) {
+			if (line.matches("^\\s*[#].*")) {
+				// ignore line-comments
+				continue;
+			}
 			int equalsIndex = line.indexOf('=');
+			if (equalsIndex == -1) {
+				continue;
+			}
 			String key = line.substring(0, equalsIndex).trim();
 			String value = line.substring(equalsIndex + 1).trim();
 			map.put(key, value);
@@ -176,7 +183,8 @@ public class I18N {
 	public String m(String key, Object... args) {
 		String result = messages.get(key);
 		if (result == null) {
-			Gdx.app.log("I18N", "No message for key " + key + ", lang " + lang);
+			Gdx.app.log("I18N", "No message for key " + key + ", lang '" + lang
+					+ "'");
 			result = key;
 		}
 

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/VarsContextTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/VarsContextTest.java
@@ -37,19 +37,12 @@
 package es.eucm.ead.engine.tests;
 
 import es.eucm.ead.engine.VarsContext;
-import es.eucm.ead.engine.mock.MockGame;
 import es.eucm.ead.schema.components.VariableDef;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class VarsContextTest {
-
-	@Before
-	public void setUp() {
-		new MockGame();
-	}
 
 	@Test
 	public void testVars() {
@@ -57,7 +50,8 @@ public class VarsContextTest {
 
 		VariableDef v = new VariableDef();
 		v.setName("var");
-		v.setInitialValue(1.0f);
+		v.setInitialValue("1.0");
+		v.setType(VariableDef.Type.FLOAT);
 		vars.registerVariable(v);
 
 		assertEquals(vars.getVariable("var").getType(), Float.class);
@@ -67,5 +61,33 @@ public class VarsContextTest {
 		assertEquals(vars.getValue("var"), 1.0f);
 		vars.setValue("var", 50.0f);
 		assertEquals(vars.getValue("var"), 50.0f);
+	}
+
+	@Test
+	public void testCopyGlobals() {
+
+		VariableDef v;
+		VarsContext a = new VarsContext();
+		VarsContext b = new VarsContext();
+
+		v = new VariableDef();
+		v.setName("v1");
+		v.setInitialValue("1.0");
+		v.setType(VariableDef.Type.FLOAT);
+		a.registerVariable(v);
+
+		v = new VariableDef();
+		v.setName(VarsContext.GLOBAL_VAR_PREFIX + "v2");
+		v.setInitialValue("2.0");
+		v.setType(VariableDef.Type.FLOAT);
+		a.registerVariable(v);
+
+		a.copyGlobalsTo(b);
+		assertEquals(b.getValue(VarsContext.GLOBAL_VAR_PREFIX + "v2"), 2.0f);
+		assertEquals(b.getValue("v1"), null);
+		a.setValue(VarsContext.GLOBAL_VAR_PREFIX + "v2", 3.0f);
+
+		b.copyGlobalsTo(a);
+		assertEquals(b.getValue(VarsContext.GLOBAL_VAR_PREFIX + "v2"), 3.0f);
 	}
 }

--- a/engine/desktop/src/test/resources/techdemo/game.json
+++ b/engine/desktop/src/test/resources/techdemo/game.json
@@ -3,4 +3,5 @@
     width: 800,
     height: 600,
     initialScene: "menu",
+    variables: [{name: "_g_lang", type: "string", initialValue: "en_US"}]
 }

--- a/engine/desktop/src/test/resources/techdemo/i18n/messages.properties
+++ b/engine/desktop/src/test/resources/techdemo/i18n/messages.properties
@@ -1,0 +1,6 @@
+# scene names
+scenes.shapes.title = Shapes
+scenes.ninepatch.title = Ninepatch
+scenes.initial.title = Initial
+scenes.changeRenderer.title = Renderers
+scenes.menu.title = Menu

--- a/schema/src/main/java/es/eucm/ead/schema/components/VariableDef.java
+++ b/schema/src/main/java/es/eucm/ead/schema/components/VariableDef.java
@@ -36,6 +36,8 @@
  */
 package es.eucm.ead.schema.components;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Generated;
 
 /**
@@ -52,10 +54,15 @@ public class VariableDef {
 	 */
 	private String name;
 	/**
+	 * One of 'string' 'float' 'integer' 'boolean'
+	 * 
+	 */
+	private VariableDef.Type type;
+	/**
 	 * Initial value for the variable.
 	 * 
 	 */
-	private Object initialValue;
+	private String initialValue;
 
 	/**
 	 * Name of the variable
@@ -74,10 +81,26 @@ public class VariableDef {
 	}
 
 	/**
+	 * One of 'string' 'float' 'integer' 'boolean'
+	 * 
+	 */
+	public VariableDef.Type getType() {
+		return type;
+	}
+
+	/**
+	 * One of 'string' 'float' 'integer' 'boolean'
+	 * 
+	 */
+	public void setType(VariableDef.Type type) {
+		this.type = type;
+	}
+
+	/**
 	 * Initial value for the variable.
 	 * 
 	 */
-	public Object getInitialValue() {
+	public String getInitialValue() {
 		return initialValue;
 	}
 
@@ -85,8 +108,41 @@ public class VariableDef {
 	 * Initial value for the variable.
 	 * 
 	 */
-	public void setInitialValue(Object initialValue) {
+	public void setInitialValue(String initialValue) {
 		this.initialValue = initialValue;
+	}
+
+	@Generated("org.jsonschema2pojo")
+	public static enum Type {
+
+		STRING("string"), FLOAT("float"), INTEGER("integer"), BOOLEAN("boolean");
+		private final String value;
+		private static Map<String, VariableDef.Type> constants = new HashMap<String, VariableDef.Type>();
+
+		static {
+			for (VariableDef.Type c : VariableDef.Type.values()) {
+				constants.put(c.value, c);
+			}
+		}
+
+		private Type(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public String toString() {
+			return this.value;
+		}
+
+		public static VariableDef.Type fromValue(String value) {
+			VariableDef.Type constant = constants.get(value);
+			if (constant == null) {
+				throw new IllegalArgumentException(value);
+			} else {
+				return constant;
+			}
+		}
+
 	}
 
 }

--- a/schema/src/main/resources/components/variabledef.json
+++ b/schema/src/main/resources/components/variabledef.json
@@ -8,8 +8,13 @@
             "type": "string",
             "description": "Name of the variable"
         },
+        "type" : {
+            "type" : "string",
+            "enum": ["string", "float", "integer", "boolean"],
+            "description": "One of 'string' 'float' 'integer' 'boolean'"
+        },
         "initialValue": {
-            "type": "any",
+            "type": "string",
             "description": "Initial value for the variable."
         }
     }


### PR DESCRIPTION
- VarDef types are restricted to string, float, integer and boolean
- Added I18N initialization in GameController using a LANGUAGE_VAR ("lang") so that games can specify their preferred language.
- Added additional sanity checks to pseudo-properties parsing in i18n
