### PR TITLE
Improved Performance Widget by creating less String objects logging only...

### DIFF
--- a/editor/core/src/main/java/es/eucm/ead/editor/view/widgets/Performance.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/view/widgets/Performance.java
@@ -41,19 +41,28 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 
 public class Performance extends Label {
+	/**
+	 * 1000 ms ~> 1 second
+	 */
+	private final static long HIT_TIME = 1000;
 
-	private long maxMemory;
+	private long maxMemory, startTime;
 
 	public Performance(Skin skin) {
 		super("", skin);
 		maxMemory = Runtime.getRuntime().maxMemory() / 1048576;
+		startTime = System.currentTimeMillis();
 	}
 
 	@Override
 	public void act(float delta) {
 		super.act(delta);
-		setText("FPS: " + Gdx.graphics.getFramesPerSecond() + "/ Mem: "
-				+ Gdx.app.getJavaHeap() / 1048576 + " of " + maxMemory + " MB");
+		final long currentTime = System.currentTimeMillis();
+		if(currentTime - startTime > HIT_TIME){
+			setText("FPS: " + Gdx.graphics.getFramesPerSecond() + "/ Mem: "
+					+ Gdx.app.getJavaHeap() / 1048576 + " of " + maxMemory + " MB");
+			startTime = currentTime;
+		}
 	}
 
 }


### PR DESCRIPTION
... once per second.

The String constructor "+" creates 3(if I remember correctly) String objects. 
This can call Dalvik GC quite ofter in Android if it's called 60 times per second in different places.

This commit changes the times setText() method it's invoked from 60 times per second to 1. 
Plus the FPS can only change once every second.
