### PR TITLE
Issue: Project (in Model) is not loaded after OpenGame action.

### DIFF
--- a/editor/core/src/main/java/es/eucm/ead/editor/assets/ProjectAssets.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/assets/ProjectAssets.java
@@ -77,7 +77,11 @@ public class ProjectAssets extends Assets {
 	}
 
 	public void loadProject(LoadedCallback callback) {
-		load(PROJECT_FILE, Project.class, new ProjectParameter(callback));
+		if(isLoaded(PROJECT_FILE, Project.class)){
+			callback.finishedLoading(super.assetManager, PROJECT_FILE, Project.class);
+		} else {
+			load(PROJECT_FILE, Project.class, new ProjectParameter(callback));
+		}
 	}
 
 	public void toJsonPath(Object object, String path) {


### PR DESCRIPTION
It seems that this change would solve an issue with the callback#finishedLoading
method invocation when the ressource was already loaded.
But still, the callback is never being called.
It's like the resource is never loaded.

How to reproduce the issue:

Go to mockup view/click New project ~> while in the new project view the
Model's project hasn't been initialized nor created.
