### PR TITLE
Fixes #179 .

### DIFF
--- a/editor/core/src/main/java/es/eucm/ead/editor/control/commands/ModelCommand.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/control/commands/ModelCommand.java
@@ -43,6 +43,7 @@ import es.eucm.ead.editor.model.events.ModelEvent;
 import es.eucm.ead.schema.editor.actors.EditorScene;
 import es.eucm.ead.schema.editor.game.EditorGame;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class ModelCommand extends Command {
@@ -64,7 +65,7 @@ public class ModelCommand extends Command {
 	public ModelEvent doCommand() {
 		model.clearListeners();
 		model.setGame(game);
-		model.setScenes(scenes);
+		model.setScenes(new HashMap<String, EditorScene>(scenes));
 		return new LoadEvent(Type.LOADED, model);
 	}
 


### PR DESCRIPTION
The first time a project was loaded, EditorIO would execute with scenes a ModelCommand, which would set Model's scenes reference equal to EditorIO scenes reference. This would cause that the second time an OpenGame would be executed, a ModelCommand would clear the previous scenes(which are the same as the current scenes because they are the same reference, ModelCommand.java line: 66), so the new Model would have 0 scenes.
Closes #179 .
