### PR TITLE
A couple of minor fixes to the release process

### DIFF
--- a/editor/desktop/pom.xml
+++ b/editor/desktop/pom.xml
@@ -149,6 +149,7 @@
 						<includes>
 							<include>README.txt</include>
 							<include>update.json</include>
+                            <include>release.json</include>
 						</includes>
 						<targetPath>${project.build.directory}</targetPath>
 					</resource>

--- a/editor/desktop/src/main/assembly/dist.xml
+++ b/editor/desktop/src/main/assembly/dist.xml
@@ -27,5 +27,12 @@
 				<include>ead2-${project.artifactId}.jar</include>
 			</includes>
 		</fileSet>
+        <fileSet>
+            <directory>target</directory>
+            <outputDirectory>/appdata/</outputDirectory>
+            <includes>
+                <include>release.json</include>
+            </includes>
+        </fileSet>
 	</fileSets>
 </assembly>

--- a/editor/desktop/src/main/assembly/release.json
+++ b/editor/desktop/src/main/assembly/release.json
@@ -1,0 +1,7 @@
+{
+    "appVersion": "${project.version}",
+    "releaseType": "${release.channel}",
+    "dev": false,
+    "os": "multiplatform",
+    "updateURL": "http://sourceforge.net/projects/e-adventure/files/ead2-${release.channel}/update.json/download"
+}


### PR DESCRIPTION
This just affects poms and stuff like that:
- Making readme and licenses actually appear on the ZIP release
- adding the appdata/release.json file to the application bundle generated by maven
