### PR TITLE
Added dependency Ashley Entity-Component framework

### DIFF
--- a/engine/core/pom.xml
+++ b/engine/core/pom.xml
@@ -58,6 +58,11 @@
 			<classifier>natives-desktop</classifier>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>es.e-ucm.com.github.stbachmann.ashley</groupId>
+            <artifactId>ashley</artifactId>
+            <version>0.1-SNAPSHOT</version>
+        </dependency>
         <!-- Commons-lang: added to use class EqualsBuilder for executing equals on two objects by reflection -->
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
After considering just copy-pasting those parts we want of the Ashley framework, I realized we actually want them all, so I've forked the project and mavenized it (https://github.com/e-ucm/ashley/tree/maven). This adds that dependency to eAdventure
