### PR TITLE
Return to the Stage viewport when the frame buffer ends.

### DIFF
--- a/editor/core/src/main/java/es/eucm/ead/editor/view/widgets/mockup/edition/draw/MeshHelper.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/view/widgets/mockup/edition/draw/MeshHelper.java
@@ -440,12 +440,9 @@ public class MeshHelper implements Disposable {
 	private void createShader() {
 		// this shader tells OpenGL where to put things
 		final String vertexShader = "attribute vec4 a_position; \n"
-				+ "uniform vec4 u_color;						\n"
 				+ "uniform mat4 u_worldView;					\n"
-				+ "varying vec4 v_color;						\n"
 				+ "void main()                  				\n"
 				+ "{                            				\n"
-				+ "   v_color = u_color;						\n"
 				+ "   gl_Position =  u_worldView * a_position;	}";
 
 		// this one tells it what goes in between the points (i.e
@@ -453,10 +450,10 @@ public class MeshHelper implements Disposable {
 		final String fragmentShader = "#ifdef GL_ES     \n"
 				+ "precision mediump float;    			\n"
 				+ "#endif                      			\n"
-				+ "varying vec4 v_color;				\n"
+				+ "uniform vec4 u_color;				\n"
 				+ "void main()                 			\n"
 				+ "{                           			\n"
-				+ "  gl_FragColor = v_color;   			}";
+				+ "  gl_FragColor = u_color;   			}";
 
 		// make an actual shader from our strings
 		ShaderProgram.pedantic = false;


### PR DESCRIPTION
Basically the framebuffer was returning to the default frame buffer view port when was ending. This is not an issue because the default view port has the same coordinates as the stage viewport, but if in the future we decide to play with multiple view ports by calling [glViewport](http://www.khronos.org/opengles/sdk/docs/man/xhtml/glViewport.xml), this could save us some problems.
