### PR TITLE
MeshHelper now uses stage coordinates.

### DIFF
--- a/editor/core/src/main/java/es/eucm/ead/editor/view/builders/mockup/edition/EditionWindow.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/view/builders/mockup/edition/EditionWindow.java
@@ -64,6 +64,7 @@ import es.eucm.ead.editor.view.widgets.mockup.edition.MoreElementComponent;
 import es.eucm.ead.editor.view.widgets.mockup.edition.MoreSceneComponent;
 import es.eucm.ead.editor.view.widgets.mockup.edition.draw.BrushStrokes;
 import es.eucm.ead.editor.view.widgets.mockup.engine.MockupEngineView;
+import es.eucm.ead.editor.view.widgets.mockup.engine.wrappers.MockupGameView;
 import es.eucm.ead.engine.I18N;
 import es.eucm.ead.schema.actors.Scene;
 import es.eucm.ead.schema.actors.SceneElement;
@@ -140,7 +141,8 @@ public abstract class EditionWindow implements ViewBuilder {
 		final MockupEngineView engineView = new MockupEngineView(controller);
 		this.center.addActor(engineView);
 
-		BrushStrokes brushStrokes = createBrushStrokes(controller);
+		BrushStrokes brushStrokes = createBrushStrokes(
+				engineView.getSceneView(), controller);
 		if (brushStrokes != null) {
 			brushStrokes.setVisible(false);
 			engineView.getSceneView().setBrushStrokes(brushStrokes);
@@ -179,8 +181,11 @@ public abstract class EditionWindow implements ViewBuilder {
 
 	/**
 	 * Creates a widget that allows the user to draw lines. May be null.
+	 * 
+	 * @param scaledView
 	 */
-	protected BrushStrokes createBrushStrokes(Controller controller) {
+	protected BrushStrokes createBrushStrokes(Actor scaledView,
+			Controller controller) {
 		return null;
 	}
 

--- a/editor/core/src/main/java/es/eucm/ead/editor/view/builders/mockup/edition/SceneEdition.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/view/builders/mockup/edition/SceneEdition.java
@@ -37,6 +37,7 @@
 package es.eucm.ead.editor.view.builders.mockup.edition;
 
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Container;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.utils.Array;
@@ -85,7 +86,8 @@ public class SceneEdition extends EditionWindow {
 	}
 
 	@Override
-	protected BrushStrokes createBrushStrokes(Controller controller) {
-		return new BrushStrokes(controller);
+	protected BrushStrokes createBrushStrokes(Actor scaledView,
+			Controller controller) {
+		return new BrushStrokes(scaledView, controller);
 	}
 }

--- a/editor/core/src/main/java/es/eucm/ead/editor/view/widgets/mockup/edition/draw/BrushStrokes.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/view/widgets/mockup/edition/draw/BrushStrokes.java
@@ -42,6 +42,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Widget;
@@ -75,16 +76,16 @@ public class BrushStrokes extends Widget implements Disposable {
 	 * necessary {@link Pixmap pixmaps} to perform undo/redo actions, erase and
 	 * save it as a {@link SceneElement}
 	 */
-	public BrushStrokes(Controller control) {
+	public BrushStrokes(Actor scaledView, Controller control) {
 		this.controller = control;
-		this.mesh = new MeshHelper(this);
+		this.mesh = new MeshHelper(scaledView);
 		addCaptureListener(new InputListener() {
 
 			@Override
 			public boolean touchDown(InputEvent event, float x, float y,
 					int pointer, int button) {
 				if (pointer == 0) {
-					mesh.input(x, y);
+					mesh.input(event.getStageX(), event.getStageY());
 				}
 				return true;
 			}
@@ -93,7 +94,7 @@ public class BrushStrokes extends Widget implements Disposable {
 			public void touchDragged(InputEvent event, float x, float y,
 					int pointer) {
 				if (pointer == 0) {
-					mesh.input(x, y);
+					mesh.input(event.getStageX(), event.getStageY());
 				}
 			}
 
@@ -101,7 +102,7 @@ public class BrushStrokes extends Widget implements Disposable {
 			public void touchUp(InputEvent event, float x, float y,
 					int pointer, int button) {
 				if (pointer == 0) {
-					mesh.touchUp(x, y);
+					mesh.touchUp(event.getStageX(), event.getStageY());
 					controller.command(mesh.getDrawLineCommand());
 				}
 			}


### PR DESCRIPTION
This simplifies the drawing by avoiding unnecessary conversions.
Also improved Javadocs.

This a step closer to a sustainable resize process that could be easily ported twards desktop platform.

Now MeshHelper needs a reference to the scaled actor (sceneView) in order to calculate the new positions when resized.
