### PR TITLE
Exporter refactored. 

### DIFF
--- a/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/Exporter.java
+++ b/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/Exporter.java
@@ -49,6 +49,7 @@ import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.badlogic.gdx.utils.reflect.Field;
 import com.badlogic.gdx.utils.reflect.ReflectionException;
+import es.eucm.ead.FieldNames;
 import es.eucm.ead.GameStructure;
 import es.eucm.ead.schema.components.ModelComponent;
 import es.eucm.ead.schema.entities.ModelEntity;
@@ -60,6 +61,12 @@ import es.eucm.ead.schema.entities.ModelEntity;
  * application (through {@link ExporterApplication}).
  */
 public class Exporter {
+
+	/**
+	 * All components belonging to this package are ignored when the game is
+	 * exported
+	 */
+	private static final String EDITOR_COMPONENTS_PACKAGE = "es.eucm.ead.schema.editor.components";
 
 	/**
 	 * Used for reading and writing game.json and scene.json files. When the
@@ -202,12 +209,9 @@ public class Exporter {
 	}
 
 	/**
-	 * Makes a superficial clone of the {@link ModelEntity} {@code source}
-	 * passed as an argument but omitting any editor {@link ModelComponent} so
-	 * the resulting entity can be parsed by the engine.
-	 * 
-	 * The copy returned is superficial since none of {@code source}'s
-	 * properties are cloned.
+	 * Makes a shallow clone of the {@link ModelEntity} {@code source} passed as
+	 * an argument but omitting any editor {@link ModelComponent} so the
+	 * resulting entity can be parsed by the engine.
 	 * 
 	 * This method makes a recursive call to process each {@link ModelEntity}
 	 * child in {@code source}.
@@ -215,22 +219,20 @@ public class Exporter {
 	 * @param source
 	 *            The {@link ModelEntity} to clone. May represent a game, a
 	 *            scene, a scene element, etc.
-	 * @return The superficial clone without editor components.
+	 * @return The shallow clone without editor components.
 	 */
 	private ModelEntity cloneEntityExcludingEditorComponents(ModelEntity source) {
 		ModelEntity clone = new ModelEntity();
 		for (Field field : ClassReflection.getDeclaredFields(source.getClass())) {
 			field.setAccessible(true);
-			if (field.getName().equals("components")) {
-				clone.setComponents(new ArrayList<ModelComponent>());
+			if (field.getName().equals(FieldNames.COMPONENTS.toString())) {
 				for (ModelComponent sourceComponent : source.getComponents()) {
 					if (!sourceComponent.getClass().getCanonicalName()
-							.contains("es.eucm.ead.schema.editor.components")) {
+							.contains(EDITOR_COMPONENTS_PACKAGE)) {
 						clone.getComponents().add(sourceComponent);
 					}
 				}
-			} else if (field.getName().equals("children")) {
-				clone.setChildren(new ArrayList<ModelEntity>());
+			} else if (field.getName().equals(FieldNames.CHILDREN.toString())) {
 				for (ModelEntity child : source.getChildren()) {
 					clone.getChildren().add(
 							cloneEntityExcludingEditorComponents(child));

--- a/editor/exporter/src/test/java/es/eucm/ead/editor/ExporterTest.java
+++ b/editor/exporter/src/test/java/es/eucm/ead/editor/ExporterTest.java
@@ -42,13 +42,13 @@ import com.badlogic.gdx.utils.Json;
 import es.eucm.ead.GameStructure;
 import es.eucm.ead.editor.exporter.ExportCallback;
 import es.eucm.ead.editor.exporter.Exporter;
-import es.eucm.ead.schema.components.ModelComponent;
-import es.eucm.ead.schema.components.behaviors.Touch;
+import es.eucm.ead.engine.components.behaviors.TouchesComponent;
+import es.eucm.ead.schema.components.behaviors.touches.Touch;
+import es.eucm.ead.schema.components.behaviors.touches.Touches;
 import es.eucm.ead.schema.components.game.GameData;
 import es.eucm.ead.schema.editor.components.EditState;
 import es.eucm.ead.schema.editor.components.Note;
 import es.eucm.ead.schema.editor.components.Versions;
-import es.eucm.ead.schema.effects.Effect;
 import es.eucm.ead.schema.effects.TemporalEffect;
 import es.eucm.ead.schema.entities.ModelEntity;
 import es.eucm.ead.schema.renderers.Image;
@@ -143,7 +143,7 @@ public class ExporterTest {
 	 *    Also creates several fake images using BufferedImage, which are referenced in the
 	 *    game definition created in (1), and copies them to the temp
 	 *    directory the game and scenes are saved to. This tests that
-	 *    {@link .Exporter#copyNonJsonFiles(FileHandle, FileHandle)}
+	 *    {@link Exporter#copyNonJsonFiles(FileHandle, FileHandle)}
 	 *    works properly.
 	 *
 	 * 3) Calls {@link Exporter#exportAsJar(String, String, String)} which in turns
@@ -157,28 +157,26 @@ public class ExporterTest {
 	public void testExportAsJAR() {
 		// Make initialization of the model
 		ModelEntity editorGame = new ModelEntity();
-		editorGame.setComponents(new ArrayList<ModelComponent>());
 		// Set some of the properties in game that belong to class Game
-		GameData gameComponent = new GameData();
-		gameComponent.setInitialScene(INITIAL_SCENE);
-		gameComponent.setWidth(WIDTH);
-		gameComponent.setHeight(HEIGHT);
-		editorGame.getComponents().add(gameComponent);
+		GameData gameData = new GameData();
+		gameData.setInitialScene(INITIAL_SCENE);
+		gameData.setWidth(WIDTH);
+		gameData.setHeight(HEIGHT);
+		editorGame.getComponents().add(gameData);
 		// Set some editor components which should
 		// not be saved to disk
-		Versions versionsComponent = new Versions();
-		versionsComponent.setAppVersion(APP_VERSION);
-		EditState editStateComponent = new EditState();
-		editStateComponent.setSceneorder(new ArrayList<String>());
-		editStateComponent.setEditScene(EDIT_SCENE);
-		editorGame.getComponents().add(versionsComponent);
-		editorGame.getComponents().add(editStateComponent);
+		Versions versions = new Versions();
+		versions.setAppVersion(APP_VERSION);
+		EditState editState = new EditState();
+		editState.setSceneorder(new ArrayList<String>());
+		editState.setEditScene(EDIT_SCENE);
+		editorGame.getComponents().add(versions);
+		editorGame.getComponents().add(editState);
 
 		// Create five scenes
 		Map<String, ModelEntity> editorScenes = new HashMap<String, ModelEntity>();
 		for (int j = 0; j < 5; j++) {
 			ModelEntity scene = new ModelEntity();
-			scene.setComponents(new ArrayList<ModelComponent>());
 			// Set editor properties (not to be saved)
 			Note noteComponent = new Note();
 			noteComponent.setDescription("Description");
@@ -188,10 +186,8 @@ public class ExporterTest {
 			// Set scene properties (to be saved)
 			// Add 2 children
 			for (int i = 0; i < 2; i++) {
-				scene.setChildren(new ArrayList<ModelEntity>());
 				// Create the scene element. All its properties must be saved
 				ModelEntity sceneElement = new ModelEntity();
-				sceneElement.setComponents(new ArrayList<ModelComponent>());
 				Image renderer = new Image();
 				if (i == 0)
 					renderer.setUri(USED_IMAGE_01.substring(
@@ -204,17 +200,18 @@ public class ExporterTest {
 				sceneElement.getComponents().add(renderer);
 
 				Touch touch = new Touch();
-				touch.setEffects(new ArrayList<Effect>());
 				TemporalEffect temporalEffect = new TemporalEffect();
 				temporalEffect.setDuration(DURATION);
 				touch.getEffects().add(temporalEffect);
-				sceneElement.getComponents().add(touch);
+				Touches touches = new Touches();
+				touches.getTouches().add(touch);
+				sceneElement.getComponents().add(touches);
 
 				scene.getChildren().add(sceneElement);
 			}
 			editorScenes.put("scene" + j, scene);
 
-			editStateComponent.getSceneorder().add("scene" + j);
+			editState.getSceneorder().add("scene" + j);
 		}
 
 		// Save the model

--- a/editor/schema/src/main/java/es/eucm/ead/FieldNames.java
+++ b/editor/schema/src/main/java/es/eucm/ead/FieldNames.java
@@ -63,6 +63,16 @@ import es.eucm.ead.schema.components.Tags;
 public enum FieldNames {
 
 	/**
+	 * Refers to {@link ModelEntity#components}
+	 */
+	COMPONENTS("components"),
+
+	/**
+	 * Refers to {@link ModelEntity#children}
+	 */
+	CHILDREN("children"),
+
+	/**
 	 * Refers to {@link Documentation#name}
 	 */
 	NAME("name"),


### PR DESCRIPTION
Now, instead of upcasting editor objects, it just omits editor components.

ExporterTest has also been adapted and now it compiles and works.
