### PR TITLE
Remove dependency of ApplicationAssets in EditorGameAssets.

### DIFF
--- a/editor/core/src/main/java/es/eucm/ead/editor/assets/EditorGameAssets.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/assets/EditorGameAssets.java
@@ -41,6 +41,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.utils.JsonWriter.OutputType;
+import es.eucm.ead.GameStructure;
 import es.eucm.ead.engine.assets.GameAssets;
 import es.eucm.ead.schema.entities.ModelEntity;
 
@@ -62,10 +63,14 @@ public class EditorGameAssets extends GameAssets {
 	 * @param files
 	 *            object granting access to files
 	 */
-	public EditorGameAssets(Files files, ApplicationAssets applicationAssets) {
+	public EditorGameAssets(Files files) {
 		super(files);
-		loadBindings(applicationAssets.resolve("bindings.json"));
 		setOutputType(OutputType.json);
+	}
+
+	@Override
+	protected FileHandle resolveBindings() {
+		return files.internal(GameStructure.BINDINGS_FILE);
 	}
 
 	public void loadAllJsonResources(AssetLoadedCallback<ModelEntity> callback) {

--- a/editor/core/src/main/java/es/eucm/ead/editor/control/Controller.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/control/Controller.java
@@ -126,7 +126,7 @@ public class Controller {
 		this.platform = platform;
 		this.requestHelper = platform.getRequestHelper();
 		this.applicationAssets = createApplicationAssets(files);
-		this.editorGameAssets = new EditorGameAssets(files, applicationAssets);
+		this.editorGameAssets = new EditorGameAssets(files);
 		this.templates = new Templates(this);
 		this.model = new Model(editorGameAssets);
 		this.commands = new Commands(model);

--- a/editor/core/src/test/java/es/eucm/ead/editor/assets/EditorGameAssetsTest.java
+++ b/editor/core/src/test/java/es/eucm/ead/editor/assets/EditorGameAssetsTest.java
@@ -73,8 +73,7 @@ public class EditorGameAssetsTest {
 
 	@Before
 	public void setUp() {
-		editorGameAssets = new EditorGameAssets(files, new ApplicationAssets(
-				files));
+		editorGameAssets = new EditorGameAssets(files);
 		projectFolder = platform.createTempFile(true);
 		editorGameAssets.setLoadingPath(projectFolder.getAbsolutePath(), true);
 	}

--- a/engine/core/src/main/java/es/eucm/ead/engine/assets/GameAssets.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/assets/GameAssets.java
@@ -67,10 +67,7 @@ public class GameAssets extends Assets implements GameStructure {
 	public GameAssets(Files files) {
 		super(files);
 		setLoaders();
-		FileHandle bindings = resolve(BINDINGS_FILE);
-		if (bindings.exists()) {
-			loadBindings(bindings);
-		}
+		loadBindings();
 	}
 
 	/**
@@ -157,9 +154,16 @@ public class GameAssets extends Assets implements GameStructure {
 	 *         found
 	 */
 	@SuppressWarnings("all")
-	public void loadBindings(FileHandle fileHandle) {
-		Array<Array<String>> bindings = fromJson(Array.class, fileHandle);
-		read(bindings);
+	public void loadBindings() {
+		FileHandle bindingsFile = resolveBindings();
+		if (bindingsFile.exists()) {
+			Array<Array<String>> bindings = fromJson(Array.class, bindingsFile);
+			read(bindings);
+		}
+	}
+
+	protected FileHandle resolveBindings() {
+		return resolve(BINDINGS_FILE);
 	}
 
 	/**


### PR DESCRIPTION
applicationAssets was only used in editorGameAssets for resolving bindings file. I think it was better to change that a little so there's no need to add that dependency
