### PR TITLE
Add .psd extension to license-ignore-list to avoid warnings on build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,7 @@
                         <exclude>**/*.atlas</exclude>
                         <exclude>**/*.glsl</exclude>
                         <exclude>**/*.svg</exclude>
+                        <exclude>**/*.psd</exclude>
                         <!-- android-related: proguard config, R-files -->
                         <exclude>**/*.cfg</exclude>
                         <exclude>**/R.java</exclude>


### PR DESCRIPTION
One-liner; avoids some 100-odd lines of warnings on mvn clean install
