### PR TITLE
Fixed missing entries from engine skin

### DIFF
--- a/assets/skins-raw/engine/skin.json
+++ b/assets/skins-raw/engine/skin.json
@@ -14,5 +14,11 @@
     },
     com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
         white: { up: white-button-up, down: white-button-down, font: regular, fontColor: white, downFontColor: light-gray }
+    },
+    com.badlogic.gdx.scenes.scene2d.ui.ImageButton$ImageButtonStyle: {
+        white: { up: white-button-up, down: white-button-down }
+    },
+    com.badlogic.gdx.scenes.scene2d.ui.Label$LabelStyle: {
+        welcome: { font: regular, fontColor: {a:0.5,r:0.0,g:0.4,b:0.9} }
     }
 }


### PR DESCRIPTION
Broken because we forgot to regenerate skins for a long, long time (and changed stuff in the "generated" skin instead).
