### PR TITLE
Remove "indexed" properties from schema, as they are no longer used

### DIFF
--- a/build-tools/generators/src/main/resources/schema/editor/components/documentation.json
+++ b/build-tools/generators/src/main/resources/schema/editor/components/documentation.json
@@ -5,11 +5,6 @@
         "$ref": "../../engine/components/component.json"
     },
     "properties": {
-        "indexed": {
-            "type": "string",
-            "description": "Comma-separated list of indexed properties (available for full-text search in editor)",
-            "default": "name"
-        },
         "name": {
             "type": "string",
             "description": "A name. Is meant to be the string that represents the entity for the user"

--- a/build-tools/generators/src/main/resources/schema/editor/components/note.json
+++ b/build-tools/generators/src/main/resources/schema/editor/components/note.json
@@ -5,11 +5,6 @@
         "$ref": "../../engine/components/component.json"
     },
     "properties": {
-        "indexed": {
-            "type": "string",
-            "description": "Comma-separated list of indexed properties (available for full-text search in editor)",
-            "default": "title, description"
-        },
         "title": {
             "type": "string",
             "description": "A title"

--- a/build-tools/generators/src/main/resources/schema/engine/components/renderers/atlasimage.json
+++ b/build-tools/generators/src/main/resources/schema/engine/components/renderers/atlasimage.json
@@ -8,11 +8,6 @@
     },
     "description": "A region in an atlas",
     "properties": {
-        "indexed": {
-            "type": "string",
-            "description": "Comma-separated list of indexed properties (available for full-text search in editor)",
-            "default": "name, uri"
-        },
         "name": {
             "type": "string"
         },

--- a/build-tools/generators/src/main/resources/schema/engine/components/renderers/image.json
+++ b/build-tools/generators/src/main/resources/schema/engine/components/renderers/image.json
@@ -7,11 +7,6 @@
     },
     "description": "An image asset",
     "properties": {
-        "indexed": {
-            "type": "string",
-            "description": "Comma-separated list of indexed properties (available for full-text search in editor)",
-            "default": "uri"
-        },
         "uri": {
             "type": "string"
         },

--- a/build-tools/generators/src/main/resources/schema/engine/components/renderers/text.json
+++ b/build-tools/generators/src/main/resources/schema/engine/components/renderers/text.json
@@ -6,11 +6,6 @@
         "$ref": "renderer.json"
     },
     "properties": {
-        "indexed": {
-            "type": "string",
-            "description": "Comma-separated list of indexed properties (available for full-text search in editor)",
-            "default": "text"
-        },
         "text": {
             "type": "string"
         },

--- a/build-tools/generators/src/main/resources/schema/engine/data/variabledef.json
+++ b/build-tools/generators/src/main/resources/schema/engine/data/variabledef.json
@@ -4,11 +4,6 @@
     "type": "object",
     "description": "A variable's definition in the game. Its type is the same as the initial value.",
     "properties": {
-        "indexed": {
-            "type": "string",
-            "description": "Comma-separated list of indexed properties (available for full-text search in editor)",
-            "default": "name, initialValue"
-        },
         "name": {
             "type": "string",
             "description": "Name of the variable"

--- a/editor/schema/src/main/java/es/eucm/ead/schema/editor/components/Note.java
+++ b/editor/schema/src/main/java/es/eucm/ead/schema/editor/components/Note.java
@@ -48,12 +48,6 @@ import es.eucm.ead.schema.components.ModelComponent;
 public class Note extends ModelComponent {
 
 	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	private String indexed = "title, description";
-	/**
 	 * A title
 	 * 
 	 */
@@ -63,24 +57,6 @@ public class Note extends ModelComponent {
 	 * 
 	 */
 	private String description;
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public String getIndexed() {
-		return indexed;
-	}
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public void setIndexed(String indexed) {
-		this.indexed = indexed;
-	}
 
 	/**
 	 * A title

--- a/engine/schema/src/main/java/es/eucm/ead/schema/data/VariableDef.java
+++ b/engine/schema/src/main/java/es/eucm/ead/schema/data/VariableDef.java
@@ -50,12 +50,6 @@ import javax.annotation.Generated;
 public class VariableDef {
 
 	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	private String indexed = "name, initialValue";
-	/**
 	 * Name of the variable
 	 * 
 	 */
@@ -70,24 +64,6 @@ public class VariableDef {
 	 * 
 	 */
 	private String initialValue;
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public String getIndexed() {
-		return indexed;
-	}
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public void setIndexed(String indexed) {
-		this.indexed = indexed;
-	}
 
 	/**
 	 * Name of the variable

--- a/engine/schema/src/main/java/es/eucm/ead/schema/renderers/AtlasImage.java
+++ b/engine/schema/src/main/java/es/eucm/ead/schema/renderers/AtlasImage.java
@@ -46,32 +46,8 @@ import javax.annotation.Generated;
 @Generated("org.jsonschema2pojo")
 public class AtlasImage extends Renderer {
 
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	private String indexed = "name, uri";
 	private String name;
 	private String uri;
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public String getIndexed() {
-		return indexed;
-	}
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public void setIndexed(String indexed) {
-		this.indexed = indexed;
-	}
 
 	public String getName() {
 		return name;

--- a/engine/schema/src/main/java/es/eucm/ead/schema/renderers/Image.java
+++ b/engine/schema/src/main/java/es/eucm/ead/schema/renderers/Image.java
@@ -49,12 +49,6 @@ import es.eucm.ead.schema.data.Polygon;
 @Generated("org.jsonschema2pojo")
 public class Image extends Renderer {
 
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	private String indexed = "uri";
 	private String uri;
 	/**
 	 * A set of polygons representing the contour of the image. Polygons
@@ -64,24 +58,6 @@ public class Image extends Renderer {
 	 * 
 	 */
 	private List<Polygon> collider = new ArrayList<Polygon>();
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public String getIndexed() {
-		return indexed;
-	}
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public void setIndexed(String indexed) {
-		this.indexed = indexed;
-	}
 
 	public String getUri() {
 		return uri;

--- a/engine/schema/src/main/java/es/eucm/ead/schema/renderers/Text.java
+++ b/engine/schema/src/main/java/es/eucm/ead/schema/renderers/Text.java
@@ -42,12 +42,6 @@ import javax.annotation.Generated;
 @Generated("org.jsonschema2pojo")
 public class Text extends Renderer {
 
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	private String indexed = "text";
 	private String text;
 	/**
 	 * this (optional) uri should point to a textstyle.json object. This allows
@@ -58,24 +52,6 @@ public class Text extends Renderer {
 	 */
 	private String styleref;
 	private TextStyle style;
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public String getIndexed() {
-		return indexed;
-	}
-
-	/**
-	 * Comma-separated list of indexed properties (available for full-text
-	 * search in editor)
-	 * 
-	 */
-	public void setIndexed(String indexed) {
-		this.indexed = indexed;
-	}
 
 	public String getText() {
 		return text;


### PR DESCRIPTION
Old versions of the index relied on them to see what needed to be indexed and what not. Now we just index all strings...
