### PR TITLE
Fix camera casts

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/SetCameraExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/SetCameraExecutor.java
@@ -150,9 +150,9 @@ public class SetCameraExecutor extends EffectExecutor<SetCamera> {
 		// ///////////////////////////
 		// Calculate new values
 		// ///////////////////////////
-		Float viewportWidth = (Float) variablesManager
+		Float viewportWidth = (float) (Integer) variablesManager
 				.getValue(VarsContext.RESERVED_VIEWPORT_WIDTH_VAR);
-		Float viewportHeight = (Float) variablesManager
+		Float viewportHeight = (float) (Integer) variablesManager
 				.getValue(VarsContext.RESERVED_VIEWPORT_HEIGHT_VAR);
 
 		// Camera width and height


### PR DESCRIPTION
it is natural to write viewport resolutions in pixels; however, viewport
calculations are done in float coordinates. This fixes, for example,
the CoolDemo
