### PR TITLE
Reverts "cannot change reserved vars" rule. This should be enforced

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/ChangeVarExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/ChangeVarExecutor.java
@@ -39,7 +39,6 @@ package es.eucm.ead.engine.systems.effects;
 import ashley.core.Entity;
 import com.badlogic.gdx.Gdx;
 import es.eucm.ead.engine.variables.VariablesManager;
-import es.eucm.ead.engine.variables.VarsContext;
 import es.eucm.ead.schema.effects.ChangeVar;
 
 /**
@@ -58,13 +57,6 @@ public class ChangeVarExecutor extends EffectExecutor<ChangeVar> {
 		if (effect.getVariable() == null) {
 			Gdx.app.debug("ChangeVarExecutor",
 					"The name of the variable cannot be null. The effect will be skipped.");
-			return;
-		}
-
-		if (effect.getVariable().startsWith(VarsContext.RESERVED_VAR_PREFIX)) {
-			Gdx.app.debug("ChangeVarExecutor",
-					"User-defined variables cannot start with "
-							+ VarsContext.RESERVED_VAR_PREFIX);
 			return;
 		}
 

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/ChangeVarExecutorTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/ChangeVarExecutorTest.java
@@ -81,15 +81,6 @@ public class ChangeVarExecutorTest extends EffectTest {
 	}
 
 	@Test
-	public void testInvalidUserDefinedVar() {
-		ChangeVar changeVar = new ChangeVar();
-		changeVar.setVariable("_var");
-		changeVar.setExpression("btrue");
-		changeVarExecutor.execute(new Entity(), changeVar);
-		assertFalse(variablesManager.isVariableDefined("_var"));
-	}
-
-	@Test
 	public void testInvalidChangeVarDoesNotThrowException() {
 		changeVarExecutor.execute(new Entity(), new ChangeVar());
 	}


### PR DESCRIPTION
in the editor (when creating user vars), but not in the engine.

The current restriction breaks runtime language change via effects.
