### PR TITLE
Effecttween fix

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
@@ -316,7 +316,7 @@ public class DefaultEngineInitializer implements EngineInitializer {
 		tweenSystem.registerBaseTweenCreator(AlphaTween.class,
 				new AlphaTweenCreator());
 		tweenSystem.registerBaseTweenCreator(EffectTween.class,
-				new EffectTweenCreator(effectsSystem));
+				new EffectTweenCreator(gameLoop, effectsSystem));
 		tweenSystem.registerBaseTweenCreator(Timeline.class,
 				new TimelineCreator(tweenSystem.getBaseTweenCreators()));
 

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/tweens/tweencreators/EffectTweenCreator.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/tweens/tweencreators/EffectTweenCreator.java
@@ -39,6 +39,8 @@ package es.eucm.ead.engine.systems.tweens.tweencreators;
 import aurelienribon.tweenengine.BaseTween;
 import aurelienribon.tweenengine.Tween;
 import aurelienribon.tweenengine.TweenCallback;
+import es.eucm.ead.engine.GameLoop;
+import es.eucm.ead.engine.components.EffectsComponent;
 import es.eucm.ead.engine.entities.EngineEntity;
 import es.eucm.ead.engine.systems.EffectsSystem;
 import es.eucm.ead.schema.components.tweens.EffectTween;
@@ -47,7 +49,10 @@ public class EffectTweenCreator extends TweenCreator<EffectTween> {
 
 	private EffectsSystem system;
 
-	public EffectTweenCreator(EffectsSystem system) {
+	private GameLoop engine;
+
+	public EffectTweenCreator(GameLoop engine, EffectsSystem system) {
+		this.engine = engine;
 		this.system = system;
 	}
 
@@ -68,7 +73,10 @@ public class EffectTweenCreator extends TweenCreator<EffectTween> {
 					@Override
 					public void onEvent(int arg0, BaseTween<?> arg1) {
 						if (arg0 == START) {
-							system.executeEffectList(schemaTween.getEffects());
+							EffectsComponent comp = engine.addAndGetComponent(
+									owner, EffectsComponent.class);
+							comp.addBehavior(null, schemaTween.getEffects());
+							system.processEntity(owner, 0F);
 						}
 					}
 				});

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AnimationTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AnimationTest.java
@@ -140,7 +140,7 @@ public class AnimationTest extends EngineTest implements MockEffectListener {
 				new RotateEffectToTween());
 
 		tweenSystem.registerBaseTweenCreator(EffectTween.class,
-				new EffectTweenCreator(effectsSystem));
+				new EffectTweenCreator(gameLoop, effectsSystem));
 		tweenSystem.registerBaseTweenCreator(MoveTween.class,
 				new MoveTweenCreator());
 		tweenSystem.registerBaseTweenCreator(ScaleTween.class,

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/EffectTweenTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/EffectTweenTest.java
@@ -148,6 +148,6 @@ public class EffectTweenTest extends TweenTest implements MockEffectListener {
 		effectsSystem.registerEffectExecutor(MockEffect.class,
 				new MockEffectExecutor());
 
-		return new EffectTweenCreator(effectsSystem);
+		return new EffectTweenCreator(gameLoop, effectsSystem);
 	}
 }


### PR DESCRIPTION
EffectTweenCreator invoked directly `EffectsSystem.executeEffectList()`. An exception was thrown, since no `_this` variable was set up, and this is the default `target` for any effect. It should just invoke `EffectsSystem.processEntity()` instead