### PR TITLE
Exporter apk improvements

### DIFF
--- a/editor/core/src/main/java/es/eucm/ead/editor/control/actions/editor/ExportGame.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/control/actions/editor/ExportGame.java
@@ -156,7 +156,8 @@ public class ExportGame extends EnabledOnLoadAction {
 						exporter.exportAsJar(jarPath, controller
 								.getEditorGameAssets().getLoadingPath(),
 								engineLibraryPath, controller.getModel()
-										.listNamedObjects(), callback);
+										.listNamedObjects(), null, null,
+								callback);
 						return null;
 					}
 				},

--- a/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/ApkIcon.java
+++ b/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/ApkIcon.java
@@ -47,7 +47,7 @@ package es.eucm.ead.editor.exporter;
  */
 public enum ApkIcon {
 	LDPI("ldpi", 36), MDPI("mdpi", 48), HDPI("hdpi", 72), XHDPI("xhdpi", 96), XXHDPI(
-			"xxhdpi", 144), XXXHDPI("xxxhdpi", 192), XXXXHDPI("xxxxhdpi", 240);
+			"xxhdpi", 144), XXXHDPI("xxxhdpi", 192);
 
 	private String suffix;
 	private int resolution;

--- a/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/Exporter.java
+++ b/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/Exporter.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 import java.util.zip.ZipOutputStream;
 
 import com.badlogic.gdx.Gdx;
@@ -562,6 +563,10 @@ public class Exporter {
 	 * @param entities
 	 *            An iterator to access in read-only mode all the
 	 *            {@link ModelEntity}s of the game (scenes, game, etc.)
+	 * @param windowWidth
+	 * @param windowHeight
+	 *            Not-null windowWidth and windowHeight specify a fixed window
+	 *            size for the game. If null, the game will just run fullscreen.
 	 * @param callback
 	 *            A simple callback to provide updates on the exportation
 	 *            progress. May be null.
@@ -569,7 +574,7 @@ public class Exporter {
 
 	public void exportAsJar(String destiny, String source,
 			String engineLibPath, Iterable<Map.Entry<String, Object>> entities,
-			ExportCallback callback) {
+			Integer windowWidth, Integer windowHeight, ExportCallback callback) {
 
 		if (engineLibPath == null || !new FileHandle(engineLibPath).exists()) {
 			if (callback != null)
@@ -583,6 +588,21 @@ public class Exporter {
 		// Create a temp directory that will hold the copy of the game (/)
 		FileHandle tempDir = FileHandle.tempDirectory("ead-export-");
 		tempDir.mkdirs();
+		// If not null windowWidth and windowHeight are provided, create
+		// apparguments file and store it
+		if (windowWidth != null && windowHeight != null) {
+			Properties properties = new Properties();
+			properties.setProperty("WindowWidth", "" + windowWidth);
+			properties.setProperty("WindowHeight", "" + windowHeight);
+			FileHandle appArgumentsFile = tempDir.child("app_arguments.txt");
+			try {
+				properties.store(appArgumentsFile.write(false),
+						"Settings for EngineJarGame");
+			} catch (IOException e) {
+				// If anything goes wrong, just delete it
+				appArgumentsFile.delete();
+			}
+		}
 		// Create a subfolder that means the root of the game in the Jar
 		// (/assets/)
 		FileHandle tempGameDir = tempDir.child(ModelStructure.JAR_GAME_FOLDER);

--- a/editor/exporter/src/test/java/es/eucm/ead/editor/ExportAsApkTest.java
+++ b/editor/exporter/src/test/java/es/eucm/ead/editor/ExportAsApkTest.java
@@ -62,6 +62,6 @@ public class ExportAsApkTest {
 		target.parent().mkdirs();
 
 		ExporterApplication.exportAsApk(projectDir.path(), null, null, null,
-				"Game Of Thrones", thumbnail.path(), target.path());
+				null, "Game Of Thrones", thumbnail.path(), target.path());
 	}
 }

--- a/engine/desktop/src/main/java/es/eucm/ead/engine/EngineJarGame.java
+++ b/engine/desktop/src/main/java/es/eucm/ead/engine/EngineJarGame.java
@@ -36,9 +36,6 @@
  */
 package es.eucm.ead.engine;
 
-import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
-
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -74,13 +71,13 @@ public class EngineJarGame {
 	 * for the application. Any image found under this folder will be treated as
 	 * an icon.
 	 */
-	public static final String APP_ICONS_PATH = "appicons/";
+	public static final String APP_ICONS_PATH = "/appicons/";
 
 	/**
 	 * Internal Java properties file with settings (e.g. window size). May not
 	 * be present. (Note: update Exporter if this value changes)
 	 */
-	public static final String APP_ARGUMENTS = "app_arguments.txt";
+	public static final String APP_ARGUMENTS = "/app_arguments.txt";
 
 	/**
 	 * Property key for setting a fixed window width. If provided,
@@ -114,7 +111,6 @@ public class EngineJarGame {
 		}
 		// Run the game
 		engine.run(GAME_PATH, true);
-		Gdx.app.setLogLevel(Application.LOG_DEBUG);
 	}
 
 	/**
@@ -142,8 +138,9 @@ public class EngineJarGame {
 					BufferedImage bufferedImage = ImageIO.read(inputStream);
 					list.add(bufferedImage);
 				} catch (IOException e) {
-					Gdx.app.debug(EngineJarGame.class.getCanonicalName(),
-							"Exception reading icon: " + iconPath, e);
+					System.out.println(EngineJarGame.class.getCanonicalName()
+							+ ": Exception reading icon: " + iconPath);
+					e.printStackTrace();
 				}
 			}
 		}
@@ -174,24 +171,26 @@ public class EngineJarGame {
 						dim.setSize(screenWidth, screenHeight);
 						return dim;
 					} catch (NumberFormatException e) {
-						Gdx.app.debug(
-								EngineJarGame.class.getCanonicalName(),
-								"Bad screen width (W) or height (H)".replace(
-										"W", "" + screenWidthStr).replace("H",
-										"" + screenHeightStr), e);
+						System.out.println(EngineJarGame.class
+								.getCanonicalName()
+								+ ": Bad screen width (W) or height (H)"
+										.replace("W", "" + screenWidthStr)
+										.replace("H", "" + screenHeightStr));
+						e.printStackTrace();
 					}
 
 				}
 			} catch (IOException e) {
-				Gdx.app.debug(EngineJarGame.class.getCanonicalName(),
-						"Exception reading " + APP_ARGUMENTS, e);
+				System.out.println(EngineJarGame.class.getCanonicalName()
+						+ ": Exception reading " + APP_ARGUMENTS);
+				e.printStackTrace();
 			}
 		}
 
 		// By default, return screen size
 		// Determine the size of the window for the game to be full screen
-		Gdx.app.debug(EngineJarGame.class.getCanonicalName(),
-				"Using default window size (full screen)");
+		System.out.println(EngineJarGame.class.getCanonicalName()
+				+ ": Using default window size (full screen)");
 		int screenWidth = Toolkit.getDefaultToolkit().getScreenSize().width;
 		int screenHeight = Toolkit.getDefaultToolkit().getScreenSize().height;
 		Dimension dim = new Dimension();

--- a/engine/desktop/src/main/java/es/eucm/ead/engine/EngineJarGame.java
+++ b/engine/desktop/src/main/java/es/eucm/ead/engine/EngineJarGame.java
@@ -67,14 +67,34 @@ public class EngineJarGame {
 	 * Relative path of the folder that contains the game assets (game.json,
 	 * scenes/sceneX.json...)
 	 */
-	private static final String GAME_PATH = "assets/";
+	public static final String GAME_PATH = "assets/";
 
 	/**
 	 * Relative path to the folder that contains the images to be used as icons
 	 * for the application. Any image found under this folder will be treated as
 	 * an icon.
 	 */
-	private static final String APP_ICONS_PATH = "appicons/";
+	public static final String APP_ICONS_PATH = "appicons/";
+
+	/**
+	 * Internal Java properties file with settings (e.g. window size). May not
+	 * be present. (Note: update Exporter if this value changes)
+	 */
+	public static final String APP_ARGUMENTS = "app_arguments.txt";
+
+	/**
+	 * Property key for setting a fixed window width. If provided,
+	 * {@link #WINDOW_HEIGHT} must be present too. (Note: update Exporter if
+	 * this value changes)
+	 */
+	public static final String WINDOW_WIDTH = "WindowWidth";
+
+	/**
+	 * Property key for setting a fixed window height. If provided,
+	 * {@link #WINDOW_WIDTH} must be present too. (Note: update Exporter if this
+	 * value changes)
+	 */
+	public static final String WINDOW_HEIGHT = "WindowHeight";
 
 	/**
 	 * App icon filenames supported
@@ -83,11 +103,10 @@ public class EngineJarGame {
 			"64.png", "128.png", "256.png", "512.png", "1024.png" };
 
 	public static void main(String args[]) {
-		// Determine the size of the window for the game to be full screen
-		int screenWidth = Toolkit.getDefaultToolkit().getScreenSize().width;
-		int screenHeight = Toolkit.getDefaultToolkit().getScreenSize().height;
 		// Create the engine
-		EngineDesktop engine = new EngineDesktop(screenWidth, screenHeight);
+		Dimension windowSize = getWindowSize();
+		EngineDesktop engine = new EngineDesktop(windowSize.width,
+				windowSize.height);
 		// Load and set app icons
 		List<? extends Image> icons = loadApplicationIcons();
 		if (icons.size() > 0) {
@@ -129,5 +148,54 @@ public class EngineJarGame {
 			}
 		}
 		return list;
+	}
+
+	/*
+	 * Calculates window size. It tries to determine window's width and height
+	 * from an internal properties file but, if unreadable or not provided, just
+	 * uses the full size of the screen
+	 */
+	private static Dimension getWindowSize() {
+		InputStream inputStream = EngineJarGame.class
+				.getResourceAsStream(APP_ARGUMENTS);
+		if (inputStream != null) {
+			Properties properties = new Properties();
+			try {
+				properties.load(inputStream);
+				Object screenWidthStr = properties.get(WINDOW_WIDTH);
+				Object screenHeightStr = properties.get(WINDOW_HEIGHT);
+				if (screenWidthStr != null && screenHeightStr != null) {
+					try {
+						Integer screenWidth = Integer.parseInt(""
+								+ screenWidthStr);
+						Integer screenHeight = Integer.parseInt(""
+								+ screenHeightStr);
+						Dimension dim = new Dimension();
+						dim.setSize(screenWidth, screenHeight);
+						return dim;
+					} catch (NumberFormatException e) {
+						Gdx.app.debug(
+								EngineJarGame.class.getCanonicalName(),
+								"Bad screen width (W) or height (H)".replace(
+										"W", "" + screenWidthStr).replace("H",
+										"" + screenHeightStr), e);
+					}
+
+				}
+			} catch (IOException e) {
+				Gdx.app.debug(EngineJarGame.class.getCanonicalName(),
+						"Exception reading " + APP_ARGUMENTS, e);
+			}
+		}
+
+		// By default, return screen size
+		// Determine the size of the window for the game to be full screen
+		Gdx.app.debug(EngineJarGame.class.getCanonicalName(),
+				"Using default window size (full screen)");
+		int screenWidth = Toolkit.getDefaultToolkit().getScreenSize().width;
+		int screenHeight = Toolkit.getDefaultToolkit().getScreenSize().height;
+		Dimension dim = new Dimension();
+		dim.setSize(screenWidth, screenHeight);
+		return dim;
 	}
 }

--- a/repo-builder/src/main/java/es/eucm/ead/repobuilder/RepoLibraryBuilder.java
+++ b/repo-builder/src/main/java/es/eucm/ead/repobuilder/RepoLibraryBuilder.java
@@ -220,7 +220,7 @@ public abstract class RepoLibraryBuilder extends EditorDemoBuilder {
 		if (properties.get(ENGINE_JAR_FOR_PREVIEW) != null) {
 			exporter.exportAsJar(destiny.path(), tempFolder.path(),
 					properties.get(ENGINE_JAR_FOR_PREVIEW),
-					allEntities.entrySet(), new ExportCallback() {
+					allEntities.entrySet(), null, null, new ExportCallback() {
 						@Override
 						public void error(String errorMessage) {
 


### PR DESCRIPTION
Three fixes/additions that come in handy, two for APK exports and one for JAR exports:
APK Exports:
- XXXXHDPI app icon removed (unsupported by Android SDK)
- Added the possibility to specify path to assetsProject, so it is easier to invoke Exporter.exportAsApk from places outside the ead project

JAR Exports:
- Added support to specify custom window width and window height.