### PR TITLE
Addentity xy

### DIFF
--- a/build-tools/generators/src/main/resources/schema/engine/effects/addentity.json
+++ b/build-tools/generators/src/main/resources/schema/engine/effects/addentity.json
@@ -26,12 +26,12 @@
         "x":{
             "type":"number",
             "description":"Overrides the x position of the entity on the screen. By default (-30000), entity's x value is used",
-            "default": -30000
+            "default": "NaN"
         },
         "y":{
             "type":"number",
             "description":"Overrides the y position of the entity on the screen. By default (-30000), entity's y value is used",
-            "default": -30000
+            "default": "NaN"
         }
     },
     "description": "An effect that adds a new entity. The entity to be added can is provided by referring to another file, using the {@code entityUri} property. The effect also supports in-out animation. The total time the entity is shown is determined as: {@code durationIn}+{@code duration}+{@code durationOut}.",

--- a/build-tools/generators/src/main/resources/schema/engine/effects/addentity.json
+++ b/build-tools/generators/src/main/resources/schema/engine/effects/addentity.json
@@ -22,8 +22,18 @@
         "animationOut":{
             "$ref": "../components/tweens/basetween.json",
             "description": "A timeline that is applied to the entity when it is removed to the scene, if any."
+        },
+        "x":{
+            "type":"number",
+            "description":"Overrides the x position of the entity on the screen. By default (-30000), entity's x value is used",
+            "default": -30000
+        },
+        "y":{
+            "type":"number",
+            "description":"Overrides the y position of the entity on the screen. By default (-30000), entity's y value is used",
+            "default": -30000
         }
     },
-    "description": "An effect that adds a new entity. The entity to be added can be provided either inside the effect, using the {@code entity} property, or by referring to another file, using the {@code entityRef} property. If both are specified, {@code entity} has priority. The effect also supports in-out animation. The total time the entity is shown is determined as: {@code durationIn}+{@code duration}+{@code durationOut}.",
+    "description": "An effect that adds a new entity. The entity to be added can is provided by referring to another file, using the {@code entityUri} property. The effect also supports in-out animation. The total time the entity is shown is determined as: {@code durationIn}+{@code duration}+{@code durationOut}.",
     "type": "object"
 }

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
@@ -62,7 +62,9 @@ import es.eucm.ead.schema.effects.RemoveEntity;
  */
 public class AddEntityExecutor extends EffectExecutor<AddEntity> {
 
-	private EntitiesLoader entitiesLoader;
+    private static final float NOT_OVERRIDE_COORDINATES = -30000.0F;
+
+    private EntitiesLoader entitiesLoader;
 
 	private VariablesManager variablesManager;
 
@@ -103,6 +105,15 @@ public class AddEntityExecutor extends EffectExecutor<AddEntity> {
 		if (target instanceof EngineEntity) {
 			EngineEntity ownerEngineEntity = (EngineEntity) target;
 			ownerEngineEntity.getGroup().addActor(entityToAdd.getGroup());
+
+            // Override entity's default x and y, if specified by the effect
+            if (effect.getX()!=NOT_OVERRIDE_COORDINATES){
+                entityToAdd.getGroup().setX(effect.getX());
+            }
+
+            if (effect.getY()!=NOT_OVERRIDE_COORDINATES){
+                entityToAdd.getGroup().setY(effect.getY());
+            }
 
 			// Update newest entity var
 			variablesManager.globalNewestEntityVar(entityToAdd);

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
@@ -62,9 +62,9 @@ import es.eucm.ead.schema.effects.RemoveEntity;
  */
 public class AddEntityExecutor extends EffectExecutor<AddEntity> {
 
-    private static final float NOT_OVERRIDE_COORDINATES = -30000.0F;
+	private static final float NOT_OVERRIDE_COORDINATES = -30000.0F;
 
-    private EntitiesLoader entitiesLoader;
+	private EntitiesLoader entitiesLoader;
 
 	private VariablesManager variablesManager;
 
@@ -106,14 +106,14 @@ public class AddEntityExecutor extends EffectExecutor<AddEntity> {
 			EngineEntity ownerEngineEntity = (EngineEntity) target;
 			ownerEngineEntity.getGroup().addActor(entityToAdd.getGroup());
 
-            // Override entity's default x and y, if specified by the effect
-            if (effect.getX()!=NOT_OVERRIDE_COORDINATES){
-                entityToAdd.getGroup().setX(effect.getX());
-            }
+			// Override entity's default x and y, if specified by the effect
+			if (effect.getX() != NOT_OVERRIDE_COORDINATES) {
+				entityToAdd.getGroup().setX(effect.getX());
+			}
 
-            if (effect.getY()!=NOT_OVERRIDE_COORDINATES){
-                entityToAdd.getGroup().setY(effect.getY());
-            }
+			if (effect.getY() != NOT_OVERRIDE_COORDINATES) {
+				entityToAdd.getGroup().setY(effect.getY());
+			}
 
 			// Update newest entity var
 			variablesManager.globalNewestEntityVar(entityToAdd);

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
@@ -62,8 +62,6 @@ import es.eucm.ead.schema.effects.RemoveEntity;
  */
 public class AddEntityExecutor extends EffectExecutor<AddEntity> {
 
-	private static final float NOT_OVERRIDE_COORDINATES = -30000.0F;
-
 	private EntitiesLoader entitiesLoader;
 
 	private VariablesManager variablesManager;
@@ -107,11 +105,11 @@ public class AddEntityExecutor extends EffectExecutor<AddEntity> {
 			ownerEngineEntity.getGroup().addActor(entityToAdd.getGroup());
 
 			// Override entity's default x and y, if specified by the effect
-			if (effect.getX() != NOT_OVERRIDE_COORDINATES) {
+			if (!Float.isNaN(effect.getX())) {
 				entityToAdd.getGroup().setX(effect.getX());
 			}
 
-			if (effect.getY() != NOT_OVERRIDE_COORDINATES) {
+			if (!Float.isNaN(effect.getY())) {
 				entityToAdd.getGroup().setY(effect.getY());
 			}
 

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddEntityTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddEntityTest.java
@@ -175,6 +175,8 @@ public class AddEntityTest extends EngineTest implements EntityListener {
 		AddEntity addEntity = new AddEntity();
 		// Create entity and get it copied to temp path
 		ModelEntity modelEntity = new ModelEntity();
+        modelEntity.setX(10);
+        modelEntity.setY(10);
 		json.toJson(modelEntity, null, null, tempFile);
 		addEntity.setEntityUri(tempFile.path());
 		EngineEntity parentEntity = entitiesLoader
@@ -195,11 +197,38 @@ public class AddEntityTest extends EngineTest implements EntityListener {
 						.getValue(VarsContext.RESERVED_NEWEST_ENTITY_VAR));
 		assertEquals("Entity added should have no components", 0,
 				entityAdded.getComponents().size);
+        // Check x and y are not overriden
+        assertEquals("X and Y should be those specified in the entity", 10, entityAdded.getGroup().getX(), 0.001F);
+        assertEquals("X and Y should be those specified in the entity", 10, entityAdded.getGroup().getY(), 0.001F);
 		// Check the entity is still there after a long time
 		gameLoop.update(1000);
 		gameLoop.update(1000);
 		assertEquals("There should be 2 entities yet", 2, count);
 	}
+
+    @Test
+    public void testOverrideXY() {
+        AddEntity addEntity = new AddEntity();
+        addEntity.setX(20);
+        addEntity.setY(20);
+        // Create entity and get it copied to temp path
+        ModelEntity modelEntity = new ModelEntity();
+        modelEntity.setX(10);
+        modelEntity.setY(10);
+        json.toJson(modelEntity, null, null, tempFile);
+        addEntity.setEntityUri(tempFile.path());
+        EngineEntity parentEntity = entitiesLoader
+                .toEngineEntity(new ModelEntity());
+        addEntityExecutor.execute(parentEntity, addEntity);
+        gameAssets.getAssetManager().finishLoading();
+        gameLoop.update(0);
+        // Get added entity
+        EngineEntity entityAdded = (EngineEntity) parentEntity.getGroup()
+                .getChildren().get(0).getUserObject();
+        // Check x and y are overriden by those specified in the effect
+        assertEquals("X and Y should be those specified in the effect", 20, entityAdded.getGroup().getX(), 0.001F);
+        assertEquals("X and Y should be those specified in the effect", 20, entityAdded.getGroup().getY(), 0.001F);
+    }
 
 	@Test
 	public void testTempEntity() {

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddEntityTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddEntityTest.java
@@ -175,8 +175,8 @@ public class AddEntityTest extends EngineTest implements EntityListener {
 		AddEntity addEntity = new AddEntity();
 		// Create entity and get it copied to temp path
 		ModelEntity modelEntity = new ModelEntity();
-        modelEntity.setX(10);
-        modelEntity.setY(10);
+		modelEntity.setX(10);
+		modelEntity.setY(10);
 		json.toJson(modelEntity, null, null, tempFile);
 		addEntity.setEntityUri(tempFile.path());
 		EngineEntity parentEntity = entitiesLoader
@@ -197,38 +197,42 @@ public class AddEntityTest extends EngineTest implements EntityListener {
 						.getValue(VarsContext.RESERVED_NEWEST_ENTITY_VAR));
 		assertEquals("Entity added should have no components", 0,
 				entityAdded.getComponents().size);
-        // Check x and y are not overriden
-        assertEquals("X and Y should be those specified in the entity", 10, entityAdded.getGroup().getX(), 0.001F);
-        assertEquals("X and Y should be those specified in the entity", 10, entityAdded.getGroup().getY(), 0.001F);
+		// Check x and y are not overriden
+		assertEquals("X and Y should be those specified in the entity", 10,
+				entityAdded.getGroup().getX(), 0.001F);
+		assertEquals("X and Y should be those specified in the entity", 10,
+				entityAdded.getGroup().getY(), 0.001F);
 		// Check the entity is still there after a long time
 		gameLoop.update(1000);
 		gameLoop.update(1000);
 		assertEquals("There should be 2 entities yet", 2, count);
 	}
 
-    @Test
-    public void testOverrideXY() {
-        AddEntity addEntity = new AddEntity();
-        addEntity.setX(20);
-        addEntity.setY(20);
-        // Create entity and get it copied to temp path
-        ModelEntity modelEntity = new ModelEntity();
-        modelEntity.setX(10);
-        modelEntity.setY(10);
-        json.toJson(modelEntity, null, null, tempFile);
-        addEntity.setEntityUri(tempFile.path());
-        EngineEntity parentEntity = entitiesLoader
-                .toEngineEntity(new ModelEntity());
-        addEntityExecutor.execute(parentEntity, addEntity);
-        gameAssets.getAssetManager().finishLoading();
-        gameLoop.update(0);
-        // Get added entity
-        EngineEntity entityAdded = (EngineEntity) parentEntity.getGroup()
-                .getChildren().get(0).getUserObject();
-        // Check x and y are overriden by those specified in the effect
-        assertEquals("X and Y should be those specified in the effect", 20, entityAdded.getGroup().getX(), 0.001F);
-        assertEquals("X and Y should be those specified in the effect", 20, entityAdded.getGroup().getY(), 0.001F);
-    }
+	@Test
+	public void testOverrideXY() {
+		AddEntity addEntity = new AddEntity();
+		addEntity.setX(20);
+		addEntity.setY(20);
+		// Create entity and get it copied to temp path
+		ModelEntity modelEntity = new ModelEntity();
+		modelEntity.setX(10);
+		modelEntity.setY(10);
+		json.toJson(modelEntity, null, null, tempFile);
+		addEntity.setEntityUri(tempFile.path());
+		EngineEntity parentEntity = entitiesLoader
+				.toEngineEntity(new ModelEntity());
+		addEntityExecutor.execute(parentEntity, addEntity);
+		gameAssets.getAssetManager().finishLoading();
+		gameLoop.update(0);
+		// Get added entity
+		EngineEntity entityAdded = (EngineEntity) parentEntity.getGroup()
+				.getChildren().get(0).getUserObject();
+		// Check x and y are overriden by those specified in the effect
+		assertEquals("X and Y should be those specified in the effect", 20,
+				entityAdded.getGroup().getX(), 0.001F);
+		assertEquals("X and Y should be those specified in the effect", 20,
+				entityAdded.getGroup().getY(), 0.001F);
+	}
 
 	@Test
 	public void testTempEntity() {


### PR DESCRIPTION
Just added a quick shortcut to AddEntity effect to specify more easily where to place new entities. 

This is quite helpful when generating animated pieces that get populated all the time with new entities of the same type but in different positions (e.g. cloud generation)