### PR TITLE
RemoveComponent stops all tweens (if needed)

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
@@ -229,7 +229,7 @@ public class DefaultEngineInitializer implements EngineInitializer {
 				new AddComponentExecutor(componentLoader));
 		effectsSystem.registerEffectExecutor(GoTo.class, new GoToExecutor());
 		effectsSystem.registerEffectExecutor(RemoveComponent.class,
-				new RemoveComponentExecutor(componentLoader));
+				new RemoveComponentExecutor(componentLoader, tweenSystem));
 		effectsSystem.registerEffectExecutor(RemoveEntity.class,
 				new RemoveEntityExecutor());
 		effectsSystem.registerEffectExecutor(ChangeEntityProperty.class,

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/RemoveComponentExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/RemoveComponentExecutor.java
@@ -39,6 +39,8 @@ package es.eucm.ead.engine.systems.effects;
 import ashley.core.Entity;
 import com.badlogic.gdx.Gdx;
 import es.eucm.ead.engine.ComponentLoader;
+import es.eucm.ead.engine.components.TweensComponent;
+import es.eucm.ead.engine.systems.tweens.TweenSystem;
 import es.eucm.ead.schema.effects.RemoveComponent;
 
 /**
@@ -53,8 +55,15 @@ public class RemoveComponentExecutor extends EffectExecutor<RemoveComponent> {
 	 */
 	private ComponentLoader componentLoader;
 
-	public RemoveComponentExecutor(ComponentLoader componentLoader) {
+	/**
+	 * Needed to force stopping animations if {@link TweensComponent} is removed
+	 */
+	private TweenSystem tweenSystem;
+
+	public RemoveComponentExecutor(ComponentLoader componentLoader,
+			TweenSystem tweenSystem) {
 		this.componentLoader = componentLoader;
+		this.tweenSystem = tweenSystem;
 	}
 
 	@Override
@@ -64,6 +73,9 @@ public class RemoveComponentExecutor extends EffectExecutor<RemoveComponent> {
 				.getComponent());
 		if (componentClass != null) {
 			target.remove(componentClass);
+			if (componentClass == TweensComponent.class) {
+				tweenSystem.stopAnimations(target);
+			}
 		} else {
 			Gdx.app.error(
 					"RemoveComponentExecutor",

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/tweens/TweenSystem.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/tweens/TweenSystem.java
@@ -102,6 +102,17 @@ public class TweenSystem extends IteratingSystem implements EntityListener {
 		tweenManager.update(deltaTime);
 	}
 
+	/**
+	 * Stops all animations associated to the given entity.
+	 */
+	public void stopAnimations(Entity entity) {
+		if (entity instanceof EngineEntity) {
+			tweenManager.killTarget(((EngineEntity) entity).getGroup());
+		} else {
+			tweenManager.killTarget(entity);
+		}
+	}
+
 	@Override
 	public void processEntity(Entity entity, float deltaTime) {
 		TweensComponent tweens = entity.getComponent(TweensComponent.class);
@@ -124,11 +135,7 @@ public class TweenSystem extends IteratingSystem implements EntityListener {
 	@Override
 	// Just kill all animations related to this entity
 	public void entityRemoved(Entity entity) {
-		if (entity instanceof EngineEntity) {
-			tweenManager.killTarget(((EngineEntity) entity).getGroup());
-		} else {
-			tweenManager.killTarget(entity);
-		}
+		stopAnimations(entity);
 	}
 
 	/**

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddRemoveComponentTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddRemoveComponentTest.java
@@ -81,7 +81,8 @@ public class AddRemoveComponentTest extends EffectTest {
 		addComponentExecutor = new AddComponentExecutor(componentLoader);
 		addComponentExecutor.initialize(gameLoop);
 
-		removeComponentExecutor = new RemoveComponentExecutor(componentLoader);
+		removeComponentExecutor = new RemoveComponentExecutor(componentLoader,
+				null);
 		removeComponentExecutor.initialize(gameLoop);
 
 		// Create a simple entity


### PR DESCRIPTION
If a TweensComponent is removed, then all tweens associated to the entity are stopped. That's necessary because otherwise it is not possible to stop animations added through an AddComponent effect (undesired inconsistent behaviour)