### PR TITLE
Improvements in renderer's reset()

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/CollidableRendererComponent.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/CollidableRendererComponent.java
@@ -63,6 +63,9 @@ public abstract class CollidableRendererComponent extends RendererComponent
 
 	@Override
 	public void reset() {
-		collider = null;
+		if (collider != null) {
+			collider.clear();
+			collider = null;
+		}
 	}
 }

--- a/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/RendererComponent.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/RendererComponent.java
@@ -40,11 +40,13 @@ import ashley.core.Component;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Pool;
 
 /**
  * Base class for renderer components
  */
-public abstract class RendererComponent extends Component {
+public abstract class RendererComponent extends Component implements
+		Pool.Poolable {
 
 	/**
 	 * Updates the renderer

--- a/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/StatesComponent.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/StatesComponent.java
@@ -123,6 +123,15 @@ public class StatesComponent extends RendererComponent {
 		return false;
 	}
 
+	@Override
+	public void reset() {
+		for (State state : states) {
+			state.rendererComponent.reset();
+		}
+		states.clear();
+		currentState = null;
+	}
+
 	private static final class State {
 
 		private Array<String> states;

--- a/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/frames/FramesComponent.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/components/renderers/frames/FramesComponent.java
@@ -40,13 +40,14 @@ import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool.Poolable;
+import com.badlogic.gdx.utils.Pools;
 import es.eucm.ead.engine.components.renderers.RendererComponent;
 import es.eucm.ead.engine.components.renderers.frames.sequences.Sequence;
 
 /**
  * Created by Javier Torrente on 2/02/14.
  */
-public class FramesComponent extends RendererComponent implements Poolable {
+public class FramesComponent extends RendererComponent {
 
 	protected Array<Frame> frames;
 	private int currentFrameIndex;
@@ -237,9 +238,13 @@ public class FramesComponent extends RendererComponent implements Poolable {
 
 	@Override
 	public void reset() {
+		for (Frame frame : frames) {
+			Pools.free(frame.renderer);
+		}
 		frames.clear();
 		currentFrame = null;
 		currentFrameIndex = 0;
+		function = null;
 	}
 
 }

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/renderers/FramesComponentTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/renderers/FramesComponentTest.java
@@ -207,6 +207,11 @@ public class FramesComponentTest {
 		public Array<Polygon> getCollider() {
 			return null;
 		}
+
+		@Override
+		public void reset() {
+
+		}
 	}
 
 }

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/StatesComponentTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/StatesComponentTest.java
@@ -201,5 +201,10 @@ public class StatesComponentTest extends EngineTest implements EntityListener {
 			collider.add(newPolygon);
 			return collider;
 		}
+
+		@Override
+		public void reset() {
+
+		}
 	}
 }


### PR DESCRIPTION
There was a nasty bug in some devices that caused bad rendering because renderer components were not being freed properly. This fixes it