### PR TITLE
Fixes parameters in Timelines

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/Accessor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/Accessor.java
@@ -618,32 +618,26 @@ public class Accessor {
 		}
 
 		if (castClass.isEnum()) {
-			for (Object enumConstant : castClass.getEnumConstants()) {
-				if (o.getClass() == String.class) { // String
-					try {
-						java.lang.reflect.Field field = enumConstant.getClass()
-								.getSuperclass().getDeclaredField("name");
-						field.setAccessible(true);
-						String constantName = (String) (field.get(enumConstant));
-						if (constantName.equalsIgnoreCase(o.toString())) {
-							return enumConstant;
-						}
-					} catch (IllegalAccessException e) {
-					} catch (NoSuchFieldException e) {
-					}
-				} else if (Number.class.isAssignableFrom(o.getClass())) { // Number
-					try {
-						java.lang.reflect.Field field = enumConstant.getClass()
-								.getSuperclass().getDeclaredField("ordinal");
-						field.setAccessible(true);
-						Integer constantOrdinal = (Integer) (field
-								.get(enumConstant));
-						if (constantOrdinal.equals(o)) {
-							return enumConstant;
-						}
-					} catch (IllegalAccessException e) {
-					} catch (NoSuchFieldException e) {
-					}
+			if (o.getClass() == String.class) { // String
+				String fieldName = o.toString();
+				Enum enumToReturn = null;
+				try {
+					enumToReturn = Enum.valueOf(castClass, fieldName);
+				} catch (IllegalArgumentException e) {
+				}
+				try {
+					enumToReturn = Enum.valueOf(castClass,
+							fieldName.toLowerCase());
+				} catch (IllegalArgumentException e) {
+				}
+				try {
+					enumToReturn = Enum.valueOf(castClass,
+							fieldName.toUpperCase());
+				} catch (IllegalArgumentException e) {
+				}
+
+				if (enumToReturn != null) {
+					return enumToReturn;
 				}
 			}
 		}

--- a/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
@@ -228,8 +228,10 @@ public class DefaultEngineInitializer implements EngineInitializer {
 				new AlphaTweenCreator());
 		tweenSystem.registerBaseTweenCreator(EffectTween.class,
 				new EffectTweenCreator(gameLoop, effectsSystem));
-		tweenSystem.registerBaseTweenCreator(Timeline.class,
-				new TimelineCreator(tweenSystem.getBaseTweenCreators()));
+		tweenSystem.registerBaseTweenCreator(
+				Timeline.class,
+				new TimelineCreator(gameAssets, variablesManager, tweenSystem
+						.getBaseTweenCreators()));
 
 		// Variables listeners
 		variablesManager.addListener(new LanguageVariableListener(gameLoop,

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/tweens/tweencreators/TimelineCreator.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/tweens/tweencreators/TimelineCreator.java
@@ -39,7 +39,10 @@ package es.eucm.ead.engine.systems.tweens.tweencreators;
 import aurelienribon.tweenengine.Timeline;
 import aurelienribon.tweenengine.Tween;
 import com.badlogic.gdx.utils.Array;
+import es.eucm.ead.engine.assets.GameAssets;
 import es.eucm.ead.engine.entities.EngineEntity;
+import es.eucm.ead.engine.utils.EngineUtils;
+import es.eucm.ead.engine.variables.VariablesManager;
 import es.eucm.ead.schema.components.tweens.BaseTween;
 import es.eucm.ead.schema.components.tweens.Timeline.Mode;
 
@@ -52,9 +55,15 @@ public class TimelineCreator extends
 		BaseTweenCreator<es.eucm.ead.schema.components.tweens.Timeline> {
 
 	private Map<Class, BaseTweenCreator> creators;
+	private GameAssets gameAssets;
+	private VariablesManager variableManager;
 
-	public TimelineCreator(Map<Class, BaseTweenCreator> creators) {
+	public TimelineCreator(GameAssets gameAssets,
+			VariablesManager variablesManager,
+			Map<Class, BaseTweenCreator> creators) {
 		this.creators = creators;
+		this.gameAssets = gameAssets;
+		this.variableManager = variablesManager;
 	}
 
 	@Override
@@ -78,7 +87,8 @@ public class TimelineCreator extends
 			BaseTweenCreator creator = creators.get(child.getClass());
 			if (creator != null) {
 				aurelienribon.tweenengine.BaseTween baseTween = creator
-						.createTween(owner, child);
+						.createTween(owner, EngineUtils.buildWithParameters(
+								gameAssets, variableManager, child));
 				if (baseTween instanceof Tween) {
 					timeline = timeline.push((Tween) baseTween);
 				} else {

--- a/engine/core/src/test/java/es/eucm/ead/engine/AccessorTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/AccessorTest.java
@@ -351,6 +351,44 @@ public class AccessorTest extends EngineTest {
 
 	}
 
+	@Test
+	public void testEnums() {
+		Object2 object2 = new Object2(0, 0);
+		Map<String, Object> rootObjects = new HashMap<String, Object>();
+		rootObjects.put("o2", object2);
+		accessor.setRootObjects(rootObjects);
+
+		// Test write enum
+		// assertEquals(1, accessor.get("o2.c2"));
+		accessor.set("o2.c2", 1);
+		assertEquals(Enum1.CONSTANT2, object2.c2);
+		try {
+			accessor.set("o2.c2", 4);
+			fail("An exception should have been thrown");
+		} catch (Accessor.AccessorException e) {
+		}
+		assertEquals(Enum1.CONSTANT2, object2.c2);
+		accessor.set("o2.c2", "CONSTANT3");
+		assertEquals(Enum1.CONSTANT3, object2.c2);
+		accessor.set("o2.c2", "constant2");
+		assertEquals(Enum1.CONSTANT2, object2.c2);
+		try {
+			accessor.set("o2.c2", "c1");
+			fail("An exception should have been thrown");
+		} catch (Accessor.AccessorException e) {
+		}
+		assertEquals(Enum1.CONSTANT2, accessor.get("o2.c2"));
+	}
+
+	private enum Enum1 {
+		CONSTANT1("c1"), CONSTANT2("c2"), CONSTANT3("c3");
+		private String val;
+
+		private Enum1(String v) {
+			this.val = v;
+		}
+	}
+
 	private class Object1 {
 		public int a1;
 		public Object2 o2;
@@ -367,10 +405,12 @@ public class AccessorTest extends EngineTest {
 
 		public int a2;
 		public int b2;
+		public Enum1 c2;
 
 		public Object2(int a, int b) {
 			this.a2 = a;
 			this.b2 = b;
+			this.c2 = Enum1.CONSTANT1;
 		}
 	}
 

--- a/engine/core/src/test/java/es/eucm/ead/engine/AccessorTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/AccessorTest.java
@@ -359,15 +359,14 @@ public class AccessorTest extends EngineTest {
 		accessor.setRootObjects(rootObjects);
 
 		// Test write enum
-		// assertEquals(1, accessor.get("o2.c2"));
-		accessor.set("o2.c2", 1);
-		assertEquals(Enum1.CONSTANT2, object2.c2);
+		// accessor.set("o2.c2", 1);
+		// assertEquals(Enum1.CONSTANT2, object2.c2);
 		try {
-			accessor.set("o2.c2", 4);
+			accessor.set("o2.c2", 1);
 			fail("An exception should have been thrown");
 		} catch (Accessor.AccessorException e) {
 		}
-		assertEquals(Enum1.CONSTANT2, object2.c2);
+		assertEquals(Enum1.CONSTANT1, object2.c2);
 		accessor.set("o2.c2", "CONSTANT3");
 		assertEquals(Enum1.CONSTANT3, object2.c2);
 		accessor.set("o2.c2", "constant2");
@@ -384,7 +383,7 @@ public class AccessorTest extends EngineTest {
 		CONSTANT1("c1"), CONSTANT2("c2"), CONSTANT3("c3");
 		private String val;
 
-		private Enum1(String v) {
+		Enum1(String v) {
 			this.val = v;
 		}
 	}

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddEntityTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/AddEntityTest.java
@@ -116,7 +116,8 @@ public class AddEntityTest extends EngineTest implements EntityListener {
 		creators.put(ScaleTween.class, scaleTweenCreator);
 		MoveTweenCreator moveTweenCreator = new MoveTweenCreator();
 		creators.put(MoveTween.class, moveTweenCreator);
-		TimelineCreator timelineCreator = new TimelineCreator(creators);
+		TimelineCreator timelineCreator = new TimelineCreator(gameAssets,
+				variablesManager, creators);
 		creators.put(Timeline.class, timelineCreator);
 
 		TweenSystem tweenSystem = new TweenSystem();

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/TimelineWithParamsTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/TimelineWithParamsTest.java
@@ -1,0 +1,160 @@
+/**
+ * eAdventure is a research project of the
+ *    e-UCM research group.
+ *
+ *    Copyright 2005-2014 e-UCM research group.
+ *
+ *    You can access a list of all the contributors to eAdventure at:
+ *          http://e-adventure.e-ucm.es/contributors
+ *
+ *    e-UCM is a research group of the Department of Software Engineering
+ *          and Artificial Intelligence at the Complutense University of Madrid
+ *          (School of Computer Science).
+ *
+ *          CL Profesor Jose Garcia Santesmases 9,
+ *          28040 Madrid (Madrid), Spain.
+ *
+ *          For more info please visit:  <http://e-adventure.e-ucm.es> or
+ *          <http://www.e-ucm.es>
+ *
+ * ****************************************************************************
+ *
+ *  This file is part of eAdventure
+ *
+ *      eAdventure is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU Lesser General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      eAdventure is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public License
+ *      along with eAdventure.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package es.eucm.ead.engine.tests.systems.tweens;
+
+import aurelienribon.tweenengine.TweenEquations;
+import aurelienribon.tweenengine.TweenManager;
+import es.eucm.ead.engine.entities.EngineEntity;
+import es.eucm.ead.engine.systems.tweens.TweenSystem;
+import es.eucm.ead.engine.systems.tweens.tweencreators.BaseTweenCreator;
+import es.eucm.ead.engine.systems.tweens.tweencreators.MoveTweenCreator;
+import es.eucm.ead.engine.systems.tweens.tweencreators.TimelineCreator;
+import es.eucm.ead.schema.components.tweens.BaseTween;
+import es.eucm.ead.schema.components.tweens.MoveTween;
+import es.eucm.ead.schema.components.tweens.Timeline;
+import es.eucm.ead.schema.components.tweens.Tween;
+import es.eucm.ead.schema.data.Parameter;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that tweens with nested tweens get all parameters executed as expected
+ * Created by jtorrente on 23/10/2015.
+ */
+public class TimelineWithParamsTest extends TweenTest {
+	@Override
+	public Class getTweenClass() {
+		return Timeline.class;
+	}
+
+	@Override
+	public BaseTweenCreator getTweenCreator() {
+		tweenSystem.registerBaseTweenCreator(MoveTween.class,
+				new MoveTweenCreator());
+		return new TimelineCreator(gameAssets, variablesManager,
+				tweenSystem.getBaseTweenCreators());
+	}
+
+	@Test
+	public void testSingleTweenParams() {
+		MoveTween moveTween = new MoveTween();
+		moveTween.setDuration(0);
+		moveTween.setEaseType(Tween.EaseType.IN);
+		moveTween.setRelative(false);
+		moveTween.setYoyo(false);
+		moveTween.setRepeat(1);
+		addParam(moveTween, "x", "i10");
+		addParam(moveTween, "y", "(+ i10 i20)");
+		addParam(moveTween, "duration", "(* i2 i4)");
+		addParam(moveTween, "yoyo", "btrue");
+		addParam(moveTween, "easeType", "sINOUT");
+		addParam(moveTween, "easeEquation", "i6");
+
+		EngineEntity engineEntity = addEntityWithTweens(moveTween);
+
+		try {
+			Field tweenManagerField = TweenSystem.class
+					.getDeclaredField("tweenManager");
+			tweenManagerField.setAccessible(true);
+			TweenManager tweenManager = (TweenManager) tweenManagerField
+					.get(tweenSystem);
+			gameLoop.update(0);
+			aurelienribon.tweenengine.Tween baseTweenAur = (aurelienribon.tweenengine.Tween) tweenManager
+					.getObjects().get(0);
+			testProperty(TweenEquations.easeInOutSine, baseTweenAur.getEasing());
+			testProperty(true, baseTweenAur.isYoyo());
+		} catch (NoSuchFieldException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+
+		gameLoop.update(8);
+		testProperty(10.0F, engineEntity.getGroup().getX());
+		testProperty(30.0F, engineEntity.getGroup().getY());
+	}
+
+	private void testProperty(Object expected, Object real) {
+		assertTrue(
+				"Value is " + real.toString() + ". Should be "
+						+ expected.toString(), real.equals(expected));
+	}
+
+	@Test
+	public void testNestedTweensAndParams() {
+		MoveTween moveTween1 = new MoveTween();
+		MoveTween moveTween2 = new MoveTween();
+		moveTween2.setDelay(1F);
+		MoveTween moveTween3 = new MoveTween();
+		moveTween3.setDelay(1F);
+		addParam(moveTween1, "x", "i1");
+		addParam(moveTween2, "x", "i2");
+		addParam(moveTween3, "x", "i3");
+
+		Timeline timeline = new Timeline();
+		timeline.setMode(Timeline.Mode.SEQUENCE);
+		timeline.getChildren().add(moveTween1);
+		Timeline innerTimeline = new Timeline();
+		innerTimeline.setMode(Timeline.Mode.SEQUENCE);
+		innerTimeline.getChildren().add(moveTween2);
+		innerTimeline.getChildren().add(moveTween3);
+		timeline.getChildren().add(innerTimeline);
+
+		EngineEntity engineEntity = addEntityWithTweens(timeline);
+		gameLoop.update(1);
+		testProperty(1F, engineEntity.getGroup().getX());
+		gameLoop.update(1);
+		testProperty(2F, engineEntity.getGroup().getX());
+		gameLoop.update(1);
+		testProperty(3F, engineEntity.getGroup().getX());
+		gameLoop.update(1);
+		testProperty(3F, engineEntity.getGroup().getX());
+	}
+
+	private void addParam(BaseTween baseTween, String name, String exp) {
+		Parameter param = new Parameter();
+		param.setName(name);
+		param.setValue(exp);
+		baseTween.getParameters().add(param);
+	}
+}

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/TimelineWithParamsTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/TimelineWithParamsTest.java
@@ -86,7 +86,7 @@ public class TimelineWithParamsTest extends TweenTest {
 		addParam(moveTween, "duration", "(* i2 i4)");
 		addParam(moveTween, "yoyo", "btrue");
 		addParam(moveTween, "easeType", "sINOUT");
-		addParam(moveTween, "easeEquation", "i6");
+		addParam(moveTween, "easeEquation", "ssine");
 
 		EngineEntity engineEntity = addEntityWithTweens(moveTween);
 

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/TweenTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/tweens/TweenTest.java
@@ -40,8 +40,8 @@ import es.eucm.ead.engine.EngineTest;
 import es.eucm.ead.engine.entities.EngineEntity;
 import es.eucm.ead.engine.processors.tweens.TweensProcessor;
 import es.eucm.ead.engine.systems.tweens.TweenSystem;
-import es.eucm.ead.engine.systems.tweens.tweencreators.TweenCreator;
-import es.eucm.ead.schema.components.tweens.BaseTween;
+import es.eucm.ead.engine.systems.tweens.tweencreators.BaseTweenCreator;
+import es.eucm.ead.schema.components.tweens.*;
 import org.junit.Before;
 
 /**
@@ -56,11 +56,23 @@ public abstract class TweenTest extends EngineTest {
 	@Before
 	public void setUp() {
 		super.setUp();
+		tweensProcessor = new TweensProcessor(gameLoop);
+		componentLoader.registerComponentProcessor(AlphaTween.class,
+				tweensProcessor);
+		componentLoader.registerComponentProcessor(FieldTween.class,
+				tweensProcessor);
+		componentLoader.registerComponentProcessor(MoveTween.class,
+				tweensProcessor);
+		componentLoader.registerComponentProcessor(RotateTween.class,
+				tweensProcessor);
+		componentLoader.registerComponentProcessor(ScaleTween.class,
+				tweensProcessor);
+		componentLoader.registerComponentProcessor(Timeline.class,
+				tweensProcessor);
 		tweenSystem = new TweenSystem();
 		gameLoop.addSystem(tweenSystem);
 		tweenSystem
 				.registerBaseTweenCreator(getTweenClass(), getTweenCreator());
-		tweensProcessor = new TweensProcessor(gameLoop);
 	}
 
 	/**
@@ -72,7 +84,7 @@ public abstract class TweenTest extends EngineTest {
 	 * @return tween creator to be registered associated with the class returned
 	 *         in {@link #getTweenClass()}
 	 */
-	public abstract TweenCreator getTweenCreator();
+	public abstract BaseTweenCreator getTweenCreator();
 
 	/**
 	 * Creates an entity with the given tween and adds it to the gameloop
@@ -80,7 +92,7 @@ public abstract class TweenTest extends EngineTest {
 	protected EngineEntity addEntityWithTweens(BaseTween... tweens) {
 		EngineEntity entity = gameLoop.createEntity();
 		for (BaseTween tween : tweens) {
-			entity.add(tweensProcessor.getComponent(tween));
+			entity.add(componentLoader.toEngineComponent(tween));
 		}
 		gameLoop.addEntity(entity);
 		return entity;


### PR DESCRIPTION
Fixes a bug that made parameters not work in Tweens when they are children of a Timeline.
Also, adds support for enums in Accessor so fields like EaseType can also be setup using parameters

(I need this for the Lemur)