### PR TITLE
Preload entity effect

### DIFF
--- a/build-tools/generators/src/main/resources/schema/engine/effects/preloadentity.json
+++ b/build-tools/generators/src/main/resources/schema/engine/effects/preloadentity.json
@@ -1,0 +1,22 @@
+{
+    "additionalProperties": false,
+    "extends": {
+        "$ref": "effect.json"
+    },
+    "javaType": "es.eucm.ead.schema.effects.PreloadEntity",
+    "properties": {
+        "entityUri":{
+            "type":"string",
+            "description": "The entity whose assets are to be loaded in memory"
+        },
+        "effects": {
+            "type": "array",
+            "items": {
+                "$ref": "effect.json"
+            },
+            "description": "A list of additional effects that can be executed once the entity has been loadad and is available in memory. Useful to improve heavy loading experiences with mini games and the such"
+        }
+    },
+    "description": "Starts loading assets of a particular entity onto memory.\nThe load runs in the background, so it does not affect or block the user interface.\nThis is useful for speeding up load of large scenes, if it can be anticipated when the scene is about to be needed.",
+    "type": "object"
+}

--- a/editor/builder/src/main/java/es/eucm/ead/builder/DemoBuilder.java
+++ b/editor/builder/src/main/java/es/eucm/ead/builder/DemoBuilder.java
@@ -158,9 +158,9 @@ public abstract class DemoBuilder {
 	protected int sceneCount;
 	protected float gameWidth;
 	protected float gameHeight;
-	private String lastSceneId;
-	private ModelEntity game;
-	private Behavior initGame;
+	protected String lastSceneId;
+	protected ModelEntity game;
+	protected Behavior initGame;
 
 	// Helper class to create expressions
 	protected ExpressionBuilder eb = new ExpressionBuilder();
@@ -1140,6 +1140,17 @@ public abstract class DemoBuilder {
 	 * {@link es.eucm.ead.schema.components.conversation.Node} or
 	 * {@link es.eucm.ead.schema.effects.controlstructures.ControlStructure}.
 	 */
+	public DemoBuilder effect(Effect effect) {
+		return effect(getLastComponent(), effect);
+	}
+
+	/**
+	 * Adds the given {@code effect} to the given {@code container}, which can
+	 * be {@link es.eucm.ead.schema.components.behaviors.Behavior},
+	 * {@link es.eucm.ead.schema.data.Script},
+	 * {@link es.eucm.ead.schema.components.conversation.Node} or
+	 * {@link es.eucm.ead.schema.effects.controlstructures.ControlStructure}.
+	 */
 	public DemoBuilder effect(Object container, Effect effect) {
 		if (container instanceof Behavior) {
 			Behavior behavior = (Behavior) container;
@@ -1786,6 +1797,67 @@ public abstract class DemoBuilder {
 	public DemoBuilder name(String name) {
 		getLastEntity().setName(name);
 		return this;
+	}
+
+	/**
+	 * Builds a {@link PreloadEntity} effect that will load in the background
+	 * the given entity, plus all the binary resources referenced in it (e.g.
+	 * images and sounds). When the process is complete, the given set of
+	 * post-effects will be launched. This can be used as a callback, or to
+	 * schedule background loading tasks in separate chunks.
+	 * 
+	 * @param entityUri
+	 *            The path of the entity to be loaded in the background (e.g.
+	 *            scenes/s1.json)
+	 * @param effects
+	 *            The set of effects to be launched once all the resources of
+	 *            the entity have been loaded (i.e. callback)
+	 */
+	public PreloadEntity makePreloadEntity(String entityUri, Effect... effects) {
+		PreloadEntity preloadEntity = new PreloadEntity();
+		preloadEntity.setEntityUri(entityUri);
+		for (Effect effect : effects) {
+			preloadEntity.getEffects().add(effect);
+		}
+		return preloadEntity;
+	}
+
+	/**
+	 * Creates a {@link PreloadEntity} object using
+	 * {@link #makePreloadEntity(String, Effect...)} and adds it to the last
+	 * component created, which is expected to be a Behavior.
+	 * 
+	 * @param entityUri
+	 *            The path of the entity to be loaded in the background (e.g.
+	 *            scenes/s1.json)
+	 * @param effects
+	 *            The set of effects to be launched once all the resources of
+	 *            the entity have been loaded (i.e. callback)
+	 * @return This DemoBuilder object, so calls can be chained
+	 */
+	public DemoBuilder preloadEntity(String entityUri, Effect... effects) {
+		return effect(makePreloadEntity(entityUri, effects));
+	}
+
+	/**
+	 * Creates a {@link PreloadEntity} object using
+	 * {@link #makePreloadEntity(String, Effect...)} and adds it to the given
+	 * container. For a list of types of containers supported, see
+	 * {@link #effect(Object, Effect)}.
+	 * 
+	 * @param container
+	 *            The object the effect will be added to
+	 * @param entityUri
+	 *            The path of the entity to be loaded in the background (e.g.
+	 *            scenes/s1.json)
+	 * @param effects
+	 *            The set of effects to be launched once all the resources of
+	 *            the entity have been loaded (i.e. callback)
+	 * @return This DemoBuilder object, so calls can be chained
+	 */
+	public DemoBuilder preloadEntity(Object container, String entityUri,
+			Effect... effects) {
+		return effect(container, makePreloadEntity(entityUri, effects));
 	}
 
 	public DemoBuilder reference(String referenceUri) {

--- a/editor/core/src/main/java/es/eucm/ead/editor/control/actions/editor/OpenGame.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/control/actions/editor/OpenGame.java
@@ -60,7 +60,7 @@ import es.eucm.ead.schema.editor.components.Parent;
 import es.eucm.ead.schema.editor.components.SceneMap;
 import es.eucm.ead.schema.editor.data.Cell;
 import es.eucm.ead.schema.entities.ModelEntity;
-import es.eucm.ead.schemax.JsonExtension;
+import es.eucm.ead.engine.utils.JsonExtension;
 import es.eucm.ead.schemax.entities.ResourceCategory;
 
 import java.util.Map.Entry;

--- a/editor/core/src/main/java/es/eucm/ead/editor/control/actions/editor/Save.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/control/actions/editor/Save.java
@@ -44,7 +44,7 @@ import es.eucm.ead.editor.model.Model.Resource;
 import es.eucm.ead.editor.model.Q;
 import es.eucm.ead.schema.editor.components.Versions;
 import es.eucm.ead.schema.entities.ModelEntity;
-import es.eucm.ead.schemax.JsonExtension;
+import es.eucm.ead.engine.utils.JsonExtension;
 
 import java.util.Map;
 

--- a/editor/core/src/main/java/es/eucm/ead/editor/utils/ProjectUtils.java
+++ b/editor/core/src/main/java/es/eucm/ead/editor/utils/ProjectUtils.java
@@ -36,20 +36,14 @@
  */
 package es.eucm.ead.editor.utils;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.reflect.ClassReflection;
-import com.badlogic.gdx.utils.reflect.Field;
-import com.badlogic.gdx.utils.reflect.ReflectionException;
 import es.eucm.ead.editor.model.Model;
-import es.eucm.ead.schema.renderers.SpineAnimation;
+import es.eucm.ead.engine.utils.ReferenceUtils;
 import es.eucm.ead.schemax.ModelStructure;
 
 import java.io.File;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Some useful methods to deal with file system and projects
@@ -57,54 +51,6 @@ import java.util.Map;
 public class ProjectUtils {
 
 	public static final String ZIP_EXTENSION = "zip";
-
-	private static final Array<String> imageExtensions = new Array<String>(
-			new String[] { "jpg", "jpeg", "png", "gif", "bmp" });
-
-	private static final Array<String> audioExtensions = new Array<String>(
-			new String[] { "mp3", "ogg", "wav" });
-
-	// To detect sound and video extensions
-	private static final Array<String> videoExtensions = new Array<String>(
-			new String[] { "mpg", "mpeg", "avi" });
-
-	/**
-	 * Checks if the given String has a binary extension. That is, if the String
-	 * ends with "." followed by a spine animation file (".json" or ".atlas"),
-	 * an image file extension ({@link #imageExtensions}), an audio file
-	 * extension ({@link #audioExtensions}), or a video file extension (
-	 * {@link #videoExtensions}). The comparison is case insensitive
-	 * 
-	 * @param strValue
-	 *            The String value to be checked
-	 * @return True if the value ends with binary format extension, false
-	 *         otherwise (or if null)
-	 */
-	public static boolean hasBinaryExtension(String strValue) {
-		if (strValue == null)
-			return false;
-		String strValueLowerCase = strValue.toLowerCase();
-		if (strValueLowerCase.endsWith(".json")
-				|| strValueLowerCase.endsWith(".atlas")) {
-			return true;
-		}
-		for (String imageExtension : imageExtensions) {
-			if (strValueLowerCase.endsWith("." + imageExtension.toLowerCase())) {
-				return true;
-			}
-		}
-		for (String binaryExtension : videoExtensions) {
-			if (strValueLowerCase.endsWith("." + binaryExtension.toLowerCase())) {
-				return true;
-			}
-		}
-		for (String binaryExtension : audioExtensions) {
-			if (strValueLowerCase.endsWith("." + binaryExtension.toLowerCase())) {
-				return true;
-			}
-		}
-		return false;
-	}
 
 	/**
 	 * @return an array with paths of all the projects inside the given folder
@@ -134,264 +80,6 @@ public class ProjectUtils {
 	 */
 	public static String createProjectName() {
 		return "mokap" + System.currentTimeMillis() + MathUtils.random(100);
-	}
-
-	/**
-	 * Searches for any reference to binary files (images, sounds and videos) in
-	 * the given
-	 * 
-	 * @param object
-	 *            . Search is performed recursively using reflection, so it can
-	 *            be used to search for references in any piece of the model,
-	 *            entity or component. The method takes into account for
-	 *            recursive search maps, libgdx's arrays, and lists. Also fields
-	 *            in any superclasses of the object are searched. It is
-	 *            considered a reference to a binary file any String field which
-	 *            value ends with any of the supported binary formats (see
-	 *            {@link #imageExtensions}, {@link #audioExtensions}) and
-	 *            {@link #videoExtensions}), either lowercase or uppercase.
-	 * 
-	 * @param object
-	 *            The object to search binary references in.
-	 */
-	public static Array<String> listRefBinaries(Object object) {
-		BinaryReferences binaryPaths = new BinaryReferences();
-		listRefBinaries(object, null, binaryPaths);
-		return binaryPaths.getReferences();
-	}
-
-	/**
-	 * Utility that searches all string fields in the given object recursively,
-	 * and replaces any occurrences of the oldRef param by the newRef Param
-	 */
-	public static void replaceBinaryRef(Object object, String oldRef,
-			String newRef) {
-		replaceBinaryRef(object, null, oldRef, newRef);
-	}
-
-	private static void listRefBinaries(Object object, Class clazz,
-			BinaryReferences binaryPaths) {
-		if (clazz == null) {
-			clazz = object.getClass();
-		}
-
-		// If the object is from primitive type, do not search
-		if (clazz.isEnum() || clazz == Float.class || clazz == Double.class
-				|| clazz == Boolean.class || clazz == Integer.class
-				|| clazz == Byte.class || clazz == Character.class
-				|| clazz == Long.class || clazz == Short.class) {
-			return;
-		}
-
-		// If the object is a String (leaf)
-		// Leaf: String
-		if (ClassReflection.isAssignableFrom(String.class, clazz)) {
-			String strValue = (String) object;
-			binaryPaths.checkAndAdd(strValue);
-		}
-		// Special case: SpineAnimation does not store extension, and therefore
-		// it needs to be treated differently
-		else if (ClassReflection.isAssignableFrom(SpineAnimation.class, clazz)) {
-			SpineAnimation spineAnimation = (SpineAnimation) object;
-			String baseUri = spineAnimation.getUri();
-			if (baseUri != null) {
-				if (baseUri.toLowerCase().endsWith(".json")) {
-					baseUri = baseUri.substring(0, baseUri.length() - 5);
-				}
-				String pngUri = baseUri + ".png";
-				String jsonUri = baseUri + ".json";
-				String atlasUri = baseUri + ".atlas";
-				// Avoid adding the same reference twice
-				binaryPaths.checkAndAdd(pngUri);
-				binaryPaths.checkAndAdd(jsonUri);
-				binaryPaths.checkAndAdd(atlasUri);
-			}
-		}
-
-		// Iterate through fields
-		for (Field field : ClassReflection.getDeclaredFields(clazz)) {
-			field.setAccessible(true);
-
-			Object value = null;
-			try {
-				value = field.get(object);
-			} catch (ReflectionException e) {
-				e.printStackTrace();
-			}
-			if (value == null) {
-				continue;
-			}
-
-			// Recursive search: array, list, map,
-			if (ClassReflection.isAssignableFrom(Array.class, field.getType())) {
-				Array array = (Array) value;
-				for (Object child : array) {
-					if (child == null) {
-						continue;
-					}
-					listRefBinaries(child, child.getClass(), binaryPaths);
-				}
-			}
-
-			else if (ClassReflection.isAssignableFrom(List.class,
-					field.getType())) {
-				List list = (List) value;
-				for (Object child : list) {
-					if (child == null) {
-						continue;
-					}
-					listRefBinaries(child, child.getClass(), binaryPaths);
-				}
-			}
-
-			else if (ClassReflection.isAssignableFrom(Map.class,
-					field.getType())) {
-				Map map = (Map) value;
-				for (Object child : map.values()) {
-					if (child == null) {
-						continue;
-					}
-					listRefBinaries(child, child.getClass(), binaryPaths);
-				}
-			}
-
-			// Recursive search
-			else {
-				listRefBinaries(value, value.getClass(), binaryPaths);
-			}
-		}
-
-		if (clazz.getSuperclass() != null) {
-			listRefBinaries(object, clazz.getSuperclass(), binaryPaths);
-		}
-	}
-
-	private static void replaceBinaryRef(Object object, Class clazz,
-			String oldRef, String newRef) {
-		if (clazz == null) {
-			clazz = object.getClass();
-		}
-
-		// If the object is from primitive type or null, do not search
-		if (object == null || clazz.isEnum() || clazz == Float.class
-				|| clazz == Double.class || clazz == Boolean.class
-				|| clazz == Integer.class || clazz == Byte.class
-				|| clazz == Character.class || clazz == Long.class
-				|| clazz == Short.class) {
-			return;
-		}
-
-		// Special case: SpineAnimation does not store extension, and therefore
-		// it needs to be treated differently
-		else if (ClassReflection.isAssignableFrom(SpineAnimation.class, clazz)) {
-			SpineAnimation spineAnimation = (SpineAnimation) object;
-			String baseUri = spineAnimation.getUri();
-			if (baseUri != null) {
-				baseUri = baseUri.toLowerCase();
-				oldRef = oldRef.toLowerCase();
-				if (baseUri.endsWith(".json")) {
-					baseUri = baseUri.substring(0, baseUri.length() - 5);
-				}
-				if (oldRef.endsWith(".json")) {
-					oldRef = oldRef.substring(0, oldRef.length() - 5);
-				}
-				if (baseUri.equals(oldRef)) {
-					spineAnimation.setUri(newRef);
-				}
-			}
-		}
-
-		// Iterate through fields
-		for (Field field : ClassReflection.getDeclaredFields(clazz)) {
-			field.setAccessible(true);
-
-			Object value = null;
-			try {
-				value = field.get(object);
-			} catch (ReflectionException e) {
-				e.printStackTrace();
-			}
-			if (value == null) {
-				continue;
-			}
-
-			// Recursive search: array, list, map,
-			if (ClassReflection.isAssignableFrom(Array.class, field.getType())) {
-				Array array = (Array) value;
-				for (int i = 0; i < array.size; i++) {
-					Object child = array.get(i);
-					if (child == null) {
-						continue;
-					} else if (child instanceof String) {
-						String strValue = (String) child;
-						if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
-							array.set(i, newRef);
-						}
-					} else {
-						replaceBinaryRef(child, child.getClass(), oldRef,
-								newRef);
-					}
-				}
-			}
-
-			else if (ClassReflection.isAssignableFrom(List.class,
-					field.getType())) {
-				List list = (List) value;
-				for (int i = 0; i < list.size(); i++) {
-					Object child = list.get(i);
-					if (child == null) {
-						continue;
-					} else if (child instanceof String) {
-						String strValue = (String) child;
-						if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
-							list.set(i, newRef);
-						}
-					} else {
-						replaceBinaryRef(child, child.getClass(), oldRef,
-								newRef);
-					}
-				}
-			}
-
-			else if (ClassReflection.isAssignableFrom(Map.class,
-					field.getType())) {
-				Map map = (Map) value;
-				for (Object key : map.keySet()) {
-					Object child = map.get(key);
-					if (child == null) {
-						continue;
-					} else if (child instanceof String) {
-						String strValue = (String) child;
-						if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
-							map.put(key, newRef);
-						}
-					} else {
-						replaceBinaryRef(child, child.getClass(), oldRef,
-								newRef);
-					}
-				}
-			} else if (ClassReflection.isAssignableFrom(String.class,
-					field.getType())) {
-				String strValue = (String) value;
-				// Check if value matches oldRef
-				if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
-					try {
-						field.set(object, newRef);
-					} catch (ReflectionException e) {
-						Gdx.app.error("Error setting binary ref in field "
-								+ field.getName(), "", e);
-					}
-				}
-			}
-			// Recursive search
-			else {
-				replaceBinaryRef(value, value.getClass(), oldRef, newRef);
-			}
-		}
-
-		if (clazz.getSuperclass() != null) {
-			replaceBinaryRef(object, clazz.getSuperclass(), oldRef, newRef);
-		}
 	}
 
 	public static String newSceneId(Model model) {
@@ -442,7 +130,7 @@ public class ProjectUtils {
 
 	public static boolean isSupportedImage(String path) {
 		path = path.toLowerCase();
-		for (String extension : imageExtensions) {
+		for (String extension : ReferenceUtils.imageExtensions) {
 			if (path.endsWith("." + extension)) {
 				return true;
 			}
@@ -461,8 +149,8 @@ public class ProjectUtils {
 	 */
 	public static boolean isSupportedAudio(FileHandle file) {
 		return !file.isDirectory()
-				&& audioExtensions.contains(file.extension().toLowerCase(),
-						false);
+				&& ReferenceUtils.audioExtensions.contains(file.extension()
+						.toLowerCase(), false);
 	}
 
 	/**
@@ -475,44 +163,5 @@ public class ProjectUtils {
 		int separatorIndex = path.lastIndexOf(File.separator);
 		return (separatorIndex < 0) ? path : path.substring(separatorIndex + 1,
 				path.length());
-	}
-
-	/**
-	 * List of unique String references (case-insensitive). Only Strings that
-	 * are not in the list are actually added (case-insensitive comparison)
-	 */
-	private static class BinaryReferences {
-		private Array<String> lowerCaseReferences;
-		private Array<String> originalReferences;
-
-		public BinaryReferences() {
-			lowerCaseReferences = new Array<String>();
-			originalReferences = new Array<String>();
-		}
-
-		/**
-		 * Adds the given String reference to the list if it is not still
-		 * present and it is a binary file
-		 * 
-		 * @param binaryReference
-		 *            The reference to be added (e.g. "image.png" or
-		 *            "sound.wav")
-		 * @return True if added, false otherwise
-		 */
-		public boolean checkAndAdd(String binaryReference) {
-			if (binaryReference == null
-					|| !hasBinaryExtension(binaryReference)
-					|| lowerCaseReferences.contains(
-							binaryReference.toLowerCase(), false)) {
-				return false;
-			}
-			lowerCaseReferences.add(binaryReference.toLowerCase());
-			originalReferences.add(binaryReference);
-			return true;
-		}
-
-		public Array<String> getReferences() {
-			return originalReferences;
-		}
 	}
 }

--- a/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/Exporter.java
+++ b/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/Exporter.java
@@ -57,7 +57,7 @@ import es.eucm.ead.schema.effects.GoScene;
 import es.eucm.ead.schema.effects.SetViewport;
 import es.eucm.ead.schema.entities.ModelEntity;
 import es.eucm.ead.schemax.FieldName;
-import es.eucm.ead.schemax.JsonExtension;
+import es.eucm.ead.engine.utils.JsonExtension;
 import es.eucm.ead.schemax.Layer;
 import es.eucm.ead.schemax.ModelStructure;
 import es.eucm.utils.gdx.ZipUtils;

--- a/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/ExporterApplication.java
+++ b/editor/exporter/src/main/java/es/eucm/ead/editor/exporter/ExporterApplication.java
@@ -43,7 +43,7 @@ import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.SerializationException;
 import es.eucm.ead.engine.assets.GameAssets;
 import es.eucm.ead.schema.entities.ModelEntity;
-import es.eucm.ead.schemax.JsonExtension;
+import es.eucm.ead.engine.utils.JsonExtension;
 import es.eucm.ead.schemax.ModelStructure;
 import es.eucm.utils.gdx.ZipUtils;
 

--- a/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
@@ -194,6 +194,9 @@ public class DefaultEngineInitializer implements EngineInitializer {
 				new SetCameraExecutor(gameView, variablesManager));
 		effectsSystem.registerEffectExecutor(PlaySound.class,
 				new PlaySoundExecutor(effectsSystem));
+		effectsSystem.registerEffectExecutor(PreloadEntity.class,
+				new PreloadEntityExecutor(entitiesLoader, effectsSystem,
+						variablesManager, gameAssets));
 
 		TrackEffectExecutor timelineExecutor = new TrackEffectExecutor(
 				effectsSystem);

--- a/engine/core/src/main/java/es/eucm/ead/engine/EntitiesLoader.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/EntitiesLoader.java
@@ -38,6 +38,7 @@ package es.eucm.ead.engine;
 
 import com.badlogic.ashley.core.Component;
 import com.badlogic.ashley.core.Entity;
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ObjectMap;
 import es.eucm.ead.engine.assets.Assets.AssetLoadedCallback;
 import es.eucm.ead.engine.assets.GameAssets;
@@ -76,6 +77,16 @@ public class EntitiesLoader implements AssetLoadedCallback<Object> {
 	}
 
 	/**
+	 * @return True if the entity stored in the given path (e.g. scenes/s1.json)
+	 *         has been loaded, or its loading has been scheduled. It returns
+	 *         false otherwise.
+	 */
+	public boolean isEntityLoaded(String path) {
+		return loading.containsKey(path)
+				|| gameAssets.isLoaded(path, Object.class);
+	}
+
+	/**
 	 * Starts loading the model entity stored in the given {@code path}. Load is
 	 * asynchronous so a {@code callback} must be passed to receive the
 	 * notification when the ModelEntity is ready.
@@ -87,16 +98,21 @@ public class EntitiesLoader implements AssetLoadedCallback<Object> {
 	 *            The callback that is notified when the process is complete
 	 */
 	public void loadEntity(String path, EntityLoadedCallback callback) {
-		loading.put(path, callback);
+		bindCallback(path, callback);
 		gameAssets.get(path, Object.class, this);
 	}
 
 	@Override
 	// This method gets invoked when an entity scheduled for loading is ready.
-	// It just notifies the associated callback.
+	// It just notifies the associated callback(s) and converts the model entity
+	// into an engine entity if necessary.
 	public void loaded(String fileName, Object modelEntity) {
 		EntityLoadedCallback callback = loading.remove(fileName);
-		callback.loaded(fileName, toEngineEntity((ModelEntity) modelEntity));
+		if (callback != null) {
+			EngineEntity engineEntity = callback.toEngine() ? toEngineEntity((ModelEntity) modelEntity)
+					: null;
+			callback.loaded(fileName, engineEntity);
+		}
 	}
 
 	@Override
@@ -151,12 +167,95 @@ public class EntitiesLoader implements AssetLoadedCallback<Object> {
 		 * @param engineEntity
 		 *            The runtime entity created.
 		 */
-		public void loaded(String path, EngineEntity engineEntity);
+		void loaded(String path, EngineEntity engineEntity);
 
 		/**
 		 * Called when the path for the entity is not found
 		 */
-		public void pathNotFound(String path);
+		void pathNotFound(String path);
+
+		/**
+		 * @return True if the callback requires {@link #EntitiesLoader} to
+		 *         convert the model entity read into an engine entity (for
+		 *         example, when the entity has to be added to {@link GameView},
+		 *         false otherwise (e.g., when the entity's resources are being
+		 *         preloaded to speed up scene transitions).
+		 */
+		boolean toEngine();
 	}
 
+	/**
+	 * Associates the given callback with the entity to be loaded from the given
+	 * path. When the entity is loaded, the callback will be retrieved and
+	 * notified of its status. More than one callback per entity is allowed,
+	 * since various petitions to load the same entity could be placed at the
+	 * same time.
+	 * 
+	 * @param path
+	 *            The path of the entity that is about to be loaded (e.g.
+	 *            scenes/s1.json)
+	 * @param newCallback
+	 *            The {@link EntityLoadedCallback} object to be associated to
+	 *            the entity
+	 */
+	private void bindCallback(String path, EntityLoadedCallback newCallback) {
+		EntityLoadedCallback mainCallback = null;
+		if (!loading.containsKey(path)) {
+			mainCallback = newCallback;
+		} else {
+			MultipleEntityLoadedCallbacks multipleEntityLoadedCallbacks = null;
+			EntityLoadedCallback prevCallback = loading.get(path);
+			if (prevCallback instanceof MultipleEntityLoadedCallbacks) {
+				multipleEntityLoadedCallbacks = (MultipleEntityLoadedCallbacks) prevCallback;
+			} else {
+				multipleEntityLoadedCallbacks = new MultipleEntityLoadedCallbacks();
+				multipleEntityLoadedCallbacks.addCallback(prevCallback);
+			}
+			multipleEntityLoadedCallbacks.addCallback(newCallback);
+			mainCallback = multipleEntityLoadedCallbacks;
+		}
+		loading.put(path, mainCallback);
+	}
+
+	/**
+	 * Just a simple implementation of {@link EntityLoadedCallback} to notify
+	 * several callbacks at the same time
+	 */
+	private static class MultipleEntityLoadedCallbacks implements
+			EntityLoadedCallback {
+
+		private Array<EntityLoadedCallback> uniqueCallbacks = new Array<EntityLoadedCallback>();
+
+		public boolean addCallback(EntityLoadedCallback callback) {
+			if (uniqueCallbacks.contains(callback, true)) {
+				return false;
+			}
+			uniqueCallbacks.add(callback);
+			return true;
+		}
+
+		@Override
+		public void loaded(String path, EngineEntity engineEntity) {
+			for (EntityLoadedCallback callback : uniqueCallbacks) {
+				callback.loaded(path, engineEntity);
+			}
+		}
+
+		@Override
+		public void pathNotFound(String path) {
+			for (EntityLoadedCallback callback : uniqueCallbacks) {
+				callback.pathNotFound(path);
+			}
+		}
+
+		@Override
+		public boolean toEngine() {
+			for (EntityLoadedCallback callback : uniqueCallbacks) {
+				if (callback.toEngine()) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
 }

--- a/engine/core/src/main/java/es/eucm/ead/engine/assets/Assets.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/assets/Assets.java
@@ -398,10 +398,22 @@ public abstract class Assets extends Json implements FileHandleResolver,
 	/**
 	 * @param fileName
 	 *            the file name of the asset
-	 * @return whether the asset is already loaded
+	 * @param type
+	 *            They type (class) the asset must have
+	 * @return whether the asset is already loaded with the given type (will
+	 *         return false if loaded but has other type)
 	 */
 	public boolean isLoaded(String fileName, Class<?> type) {
 		return assetManager.isLoaded(fileName, type);
+	}
+
+	/**
+	 * @param fileName
+	 *            the file name of the asset
+	 * @return whether the asset is already loaded
+	 */
+	public boolean isLoaded(String fileName) {
+		return assetManager.isLoaded(fileName);
 	}
 
 	/**
@@ -444,7 +456,7 @@ public abstract class Assets extends Json implements FileHandleResolver,
 	/**
 	 * Clear and disposes all loaded assets. This method is used from
 	 * {@link GameAssets} and also to dispose the loaded thumbnails from
-	 * {@link AplicationAssets}.
+	 * {@code AplicationAssets}.
 	 */
 	public void clear() {
 		Gdx.app.debug("Assets", "Clearing " + assetManager.getDiagnostics());

--- a/engine/core/src/main/java/es/eucm/ead/engine/assets/MediaResourcesLoader.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/assets/MediaResourcesLoader.java
@@ -1,0 +1,125 @@
+/**
+ * eAdventure is a research project of the
+ *    e-UCM research group.
+ *
+ *    Copyright 2005-2014 e-UCM research group.
+ *
+ *    You can access a list of all the contributors to eAdventure at:
+ *          http://e-adventure.e-ucm.es/contributors
+ *
+ *    e-UCM is a research group of the Department of Software Engineering
+ *          and Artificial Intelligence at the Complutense University of Madrid
+ *          (School of Computer Science).
+ *
+ *          CL Profesor Jose Garcia Santesmases 9,
+ *          28040 Madrid (Madrid), Spain.
+ *
+ *          For more info please visit:  <http://e-adventure.e-ucm.es> or
+ *          <http://www.e-ucm.es>
+ *
+ * ****************************************************************************
+ *
+ *  This file is part of eAdventure
+ *
+ *      eAdventure is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU Lesser General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      eAdventure is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public License
+ *      along with eAdventure.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package es.eucm.ead.engine.assets;
+
+import com.badlogic.gdx.audio.Music;
+
+/**
+ * Simple tool with static methods for loading media resources in the background
+ * like sounds, music and images using a {@link GameAssets} object Created by
+ * jtorrente on 06/11/2015.
+ */
+public class MediaResourcesLoader {
+	public static final long MAX_COMPRESSED_SOUND_SIZE = 150 * 1024;
+
+	/**
+	 * Tells the {@link GameAssets} object to load the image (png, jpg, etc)
+	 * file at path {@code imageUri} and notify {@code callback} when it's ready
+	 * or an error occurred.
+	 * 
+	 * @param imageUri
+	 *            The path of the image to load (e.g. file1.png,
+	 *            images/file2.jpg)
+	 * @param gameAssets
+	 *            The object that will actually load the resource in the
+	 *            background
+	 * @param callback
+	 *            Object that gets notifications on the status of the loading
+	 *            task
+	 */
+	public static void loadImage(String imageUri, GameAssets gameAssets,
+			final Assets.AssetLoadedCallback callback) {
+		gameAssets.get(imageUri + ".tex", ScaledTexture.class, callback);
+	}
+
+	/**
+	 * Tells the {@link GameAssets} object to load the audio (wav, mp3) file at
+	 * path {@code soundUri} and notify {@code callback} when it's ready or an
+	 * error occurred. If the file's weight is smaller than
+	 * {@value #MAX_COMPRESSED_SOUND_SIZE}, the audio file will be loaded using
+	 * Libgdx's {@link com.badlogic.gdx.audio.Sound}. Otherwise it will be
+	 * loaded using {@link com.badlogic.gdx.audio.Music}
+	 * 
+	 * @param soundUri
+	 *            The path of the sound or music to load (e.g. file1.wav,
+	 *            sounds/file2.mp3)
+	 * @param gameAssets
+	 *            The object that will actually load the resource in the
+	 *            background
+	 * @param callback
+	 *            Object that gets notifications on the status of the loading
+	 *            task
+	 */
+	public static void loadAudio(String soundUri, GameAssets gameAssets,
+			final Assets.AssetLoadedCallback callback) {
+		// files over 150k should be streamed as music; asume ~ 10x compression
+		if (gameAssets.resolve(soundUri).length() < MAX_COMPRESSED_SOUND_SIZE) {
+			gameAssets
+					.get(soundUri,
+							com.badlogic.gdx.audio.Sound.class,
+							new Assets.AssetLoadedCallback<com.badlogic.gdx.audio.Sound>() {
+								@Override
+								public void loaded(String fileName,
+										com.badlogic.gdx.audio.Sound asset) {
+									callback.loaded(fileName, asset);
+								}
+
+								@Override
+								public void error(String fileName, Class type,
+										Throwable exception) {
+									callback.error(fileName, type, exception);
+								}
+							});
+		} else {
+			gameAssets.get(soundUri, com.badlogic.gdx.audio.Music.class,
+					new Assets.AssetLoadedCallback<Music>() {
+						@Override
+						public void loaded(String fileName,
+								com.badlogic.gdx.audio.Music asset) {
+							callback.loaded(fileName, asset);
+						}
+
+						@Override
+						public void error(String fileName, Class type,
+								Throwable exception) {
+							callback.error(fileName, type, exception);
+						}
+					});
+		}
+	}
+
+}

--- a/engine/core/src/main/java/es/eucm/ead/engine/processors/renderers/ImageProcessor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/processors/renderers/ImageProcessor.java
@@ -42,6 +42,7 @@ import com.badlogic.gdx.utils.Array;
 import es.eucm.ead.engine.GameLoop;
 import es.eucm.ead.engine.assets.Assets.AssetLoadedCallback;
 import es.eucm.ead.engine.assets.GameAssets;
+import es.eucm.ead.engine.assets.MediaResourcesLoader;
 import es.eucm.ead.engine.assets.ScaledTexture;
 import es.eucm.ead.engine.components.renderers.ImageActor;
 import es.eucm.ead.engine.components.renderers.RendererComponent;
@@ -61,7 +62,7 @@ public class ImageProcessor extends RendererProcessor<Image> {
 		imageActor.setName(image.getUri());
 		rendererComponent.setRenderer(imageActor);
 
-		gameAssets.get(image.getUri() + ".tex", ScaledTexture.class,
+		MediaResourcesLoader.loadImage(image.getUri(), gameAssets,
 				new AssetLoadedCallback<ScaledTexture>() {
 					@Override
 					public void loaded(String fileName, ScaledTexture asset) {

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/AddEntityExecutor.java
@@ -89,6 +89,11 @@ public class AddEntityExecutor extends EffectExecutor<AddEntity> {
 							Gdx.app.error("AddEntityExecutor",
 									"Entity not found in " + path);
 						}
+
+						@Override
+						public boolean toEngine() {
+							return true;
+						}
 					});
 		} else {
 			// Just log that the effect will be skipped

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/GoSceneExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/GoSceneExecutor.java
@@ -150,6 +150,11 @@ public class GoSceneExecutor extends EffectExecutor<GoScene> implements
 		finish();
 	}
 
+	@Override
+	public boolean toEngine() {
+		return true;
+	}
+
 	protected void finish() {
 		transitionManager.remove();
 		gameLoop.setPlaying(true);

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/PreloadEntityExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/PreloadEntityExecutor.java
@@ -1,0 +1,284 @@
+/**
+ * eAdventure is a research project of the
+ *    e-UCM research group.
+ *
+ *    Copyright 2005-2014 e-UCM research group.
+ *
+ *    You can access a list of all the contributors to eAdventure at:
+ *          http://e-adventure.e-ucm.es/contributors
+ *
+ *    e-UCM is a research group of the Department of Software Engineering
+ *          and Artificial Intelligence at the Complutense University of Madrid
+ *          (School of Computer Science).
+ *
+ *          CL Profesor Jose Garcia Santesmases 9,
+ *          28040 Madrid (Madrid), Spain.
+ *
+ *          For more info please visit:  <http://e-adventure.e-ucm.es> or
+ *          <http://www.e-ucm.es>
+ *
+ * ****************************************************************************
+ *
+ *  This file is part of eAdventure
+ *
+ *      eAdventure is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU Lesser General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      eAdventure is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public License
+ *      along with eAdventure.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package es.eucm.ead.engine.systems.effects;
+
+import com.badlogic.ashley.core.Entity;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.utils.Array;
+import es.eucm.ead.engine.EntitiesLoader;
+import es.eucm.ead.engine.assets.Assets;
+import es.eucm.ead.engine.assets.GameAssets;
+import es.eucm.ead.engine.assets.MediaResourcesLoader;
+import es.eucm.ead.engine.systems.EffectsSystem;
+import es.eucm.ead.engine.utils.ReferenceUtils;
+import es.eucm.ead.engine.variables.VariablesManager;
+import es.eucm.ead.schema.effects.PreloadEntity;
+import es.eucm.ead.schema.entities.ModelEntity;
+
+import java.util.HashMap;
+
+/**
+ * Loads a specific entity plus all its binary resources associated in the
+ * background (Executes effects of type {@link PreloadEntity}). The logic for
+ * loading an entity is as follows: 1. The model entity is loaded from json, if
+ * not loaded yet (see {@link #loadEntity(Entity, PreloadEntity)}). 2. The model
+ * entity is searched for references to image, video and audio files. Any of
+ * these files that are not yet available in memory are loaded. 3. Once the
+ * model entity and all its binary resources are loaded, the set of post-effects
+ * are launched.
+ * 
+ * Created by jtorrente on 04/11/2015.
+ */
+public class PreloadEntityExecutor extends EffectExecutor<PreloadEntity> {
+
+	public static final String LOG_TAG = "PreloadEntityEffect";
+	private EntitiesLoader entitiesLoader;
+	private EffectsSystem effectsSystem;
+	private VariablesManager variablesManager;
+	private GameAssets gameAssets;
+	private HashMap<String, Entity> localEntities;
+
+	public PreloadEntityExecutor(EntitiesLoader entitiesLoader,
+			final EffectsSystem effectsSystem,
+			VariablesManager variablesManager, GameAssets gameAssets) {
+		this.entitiesLoader = entitiesLoader;
+		this.effectsSystem = effectsSystem;
+		this.variablesManager = variablesManager;
+		this.gameAssets = gameAssets;
+		this.localEntities = new HashMap<String, Entity>();
+	}
+
+	@Override
+	public void execute(Entity target, final PreloadEntity effect) {
+		loadEntity(target, effect);
+	}
+
+	/**
+	 * Checks if the entity to be loaded is already available in memory. If that
+	 * is the case, it launches the post effects. Otherwise, it will ask the
+	 * {@link GameAssets} object to start loading it.
+	 */
+	private void loadEntity(Entity target, final PreloadEntity effect) {
+		this.localEntities.put(effect.getEntityUri(), target);
+		if (!entitiesLoader.isEntityLoaded(effect.getEntityUri())) {
+			Gdx.app.postRunnable(new Runnable() {
+				@Override
+				public void run() {
+					gameAssets.addAssetListener(new Callback(effect));
+					gameAssets.load(effect.getEntityUri(), Object.class);
+				}
+			});
+		} else {
+			Gdx.app.log(LOG_TAG, "Entity in path: " + effect.getEntityUri()
+					+ " was already loaded. Launching effects now (if any)");
+			runPostEffects(effect);
+		}
+	}
+
+	/**
+	 * Gets notifications on the loading status of the entities/resources for a
+	 * particular {@link PreloadEntity} effect.
+	 */
+	private class Callback implements Assets.AssetLoadingListener {
+
+		private PreloadEntity effect;
+		private ModelEntity modelEntity;
+		private HashMap<String, Boolean> pendingAssets = new HashMap<String, Boolean>();
+		private int counter = 0;
+		private Listener listener = new Listener();
+
+		public Callback(PreloadEntity effect) {
+			this.effect = effect;
+		}
+
+		@Override
+		public boolean listenTo(String fileName) {
+			return fileName != null && (fileName.equals(effect.getEntityUri()));
+		}
+
+		@Override
+		public void loaded(String fileName, Object asset, Assets assets) {
+			loadBinaryRefs(fileName, asset);
+		}
+
+		/**
+		 * Searches the {@link ModelEntity} loaded for binary references and
+		 * starts loading all that have not been loaded yet. Invoked once the
+		 * model entity has been read from json.
+		 * 
+		 * @param fileName
+		 *            The path of the entity that was loaded
+		 * @param asset
+		 *            The {@link ModelEntity} object.
+		 */
+		private void loadBinaryRefs(String fileName, Object asset) {
+			if (modelEntity == null && fileName.equals(effect.getEntityUri())) {
+				Gdx.app.log(LOG_TAG, "Entity in path: " + fileName
+						+ " was loaded. Loading referenced files now");
+				modelEntity = (ModelEntity) asset;
+				Array<String> binaryRefs = ReferenceUtils
+						.listRefBinaries(modelEntity);
+				int queued = 0;
+				for (String binaryRef : binaryRefs) {
+					if (checkPendingAsset(binaryRef)) {
+						continue;
+					}
+					if (ReferenceUtils.hasImageExtension(binaryRef)) {
+						if (loadImage(binaryRef)) {
+							queued++;
+						}
+					} else if (ReferenceUtils.hasAudioExtension(binaryRef)) {
+						if (loadSound(binaryRef)) {
+							queued++;
+						}
+					} else if (ReferenceUtils.hasVideoExtension(binaryRef)) {
+						// TODO Video is not really supported yet
+					}
+				}
+
+				if (queued == 0) {
+					Gdx.app.log(LOG_TAG,
+							"No references to binary files found. Launching post-ffects now (if any)");
+					runPostEffects(effect);
+				}
+			}
+		}
+
+		private synchronized boolean loadImage(final String imgUri) {
+			if (gameAssets.isLoaded(imgUri)) {
+				return false;
+			}
+			Gdx.app.log(LOG_TAG, "Queuing load of image " + imgUri
+					+ ", referenced in " + effect.getEntityUri() + ".");
+			pendingAssets.put(imgUri + ".tex", false);
+			counter++;
+
+			Gdx.app.postRunnable(new Runnable() {
+
+				@Override
+				public void run() {
+
+					MediaResourcesLoader
+							.loadImage(imgUri, gameAssets, listener);
+
+				}
+			});
+
+			return true;
+		}
+
+		private synchronized boolean loadSound(final String soundUri) {
+			if (gameAssets.isLoaded(soundUri)) {
+				return false;
+			}
+			Gdx.app.log(LOG_TAG, "Queuing load of sound " + soundUri
+					+ ", referenced in " + effect.getEntityUri() + ".");
+			pendingAssets.put(soundUri, false);
+			counter++;
+
+			Gdx.app.postRunnable(new Runnable() {
+
+				@Override
+				public void run() {
+
+					MediaResourcesLoader.loadAudio(soundUri, gameAssets,
+							listener);
+
+				}
+			});
+
+			return true;
+		}
+
+		/**
+		 * Annotates that the resource {@code fileName} has been loaded and, if
+		 * applicable, that there is one binary resource less to be loaded for
+		 * this particular {@link PreloadEntity} effect. After that, if there
+		 * are no more pending resources, the post effects are launched. Invoked
+		 * after a binary resource has been loaded.
+		 * 
+		 * @param fileName
+		 *            Name of the file that was loaded
+		 */
+		private synchronized void update(String fileName) {
+			if (!pendingAssets.get(fileName)) {
+				Gdx.app.log(LOG_TAG, "Resource or entity " + fileName
+						+ ", referenced in " + effect.getEntityUri()
+						+ ", was loaded. Counter is:" + (counter - 1));
+				pendingAssets.put(fileName, true);
+				counter--;
+			}
+			if (counter == 0) {
+				Gdx.app.log(LOG_TAG, "Entity in path: " + effect.getEntityUri()
+						+ " was fully loaded. Launching effects now (if any)");
+				runPostEffects(effect);
+			}
+		}
+
+		private synchronized boolean checkPendingAsset(String fileName) {
+			return pendingAssets.containsKey(fileName);
+		}
+
+		@Override
+		public void unloaded(String fileName, Assets assets) {
+			// Do nothing, for now
+		}
+
+		private class Listener implements Assets.AssetLoadedCallback {
+			@Override
+			public void loaded(String fileName, Object asset) {
+				update(fileName);
+			}
+
+			@Override
+			public void error(String fileName, Class type, Throwable exception) {
+				Gdx.app.error(LOG_TAG, "Impossible to load resource: "
+						+ fileName, exception);
+			}
+		}
+	}
+
+	private void runPostEffects(PreloadEntity effect) {
+		if (effect.getEffects().size > 0) {
+			variablesManager.push();
+			variablesManager.localOwnerVar(localEntities.get(effect
+					.getEntityUri()));
+			effectsSystem.executeEffectList(effect.getEffects());
+			variablesManager.pop();
+		}
+	}
+}

--- a/engine/core/src/main/java/es/eucm/ead/engine/utils/JsonExtension.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/utils/JsonExtension.java
@@ -34,7 +34,7 @@
  *      You should have received a copy of the GNU Lesser General Public License
  *      along with eAdventure.  If not, see <http://www.gnu.org/licenses/>.
  */
-package es.eucm.ead.schemax;
+package es.eucm.ead.engine.utils;
 
 /**
  * Convenient utility for handling Json extensions in {@code String}s and

--- a/engine/core/src/main/java/es/eucm/ead/engine/utils/ReferenceUtils.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/utils/ReferenceUtils.java
@@ -80,16 +80,76 @@ public class ReferenceUtils {
 				|| strValueLowerCase.endsWith(".atlas")) {
 			return true;
 		}
+		if (hasImageExtension(strValue)) {
+			return true;
+		}
+		if (hasVideoExtension(strValue)) {
+			return true;
+		}
+		if (hasAudioExtension(strValue)) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Checks if the given String has image extension. That is, if the String
+	 * ends with "." followed by a one of the file extensions in
+	 * {@link #imageExtensions}. The comparison is case insensitive
+	 * 
+	 * @param strValue
+	 *            The String value to be checked
+	 * @return True if the value ends with image format extension, false
+	 *         otherwise (or if null)
+	 */
+	public static boolean hasImageExtension(String strValue) {
+		if (strValue == null)
+			return false;
+		String strValueLowerCase = strValue.toLowerCase();
 		for (String imageExtension : imageExtensions) {
 			if (strValueLowerCase.endsWith("." + imageExtension.toLowerCase())) {
 				return true;
 			}
 		}
+		return false;
+	}
+
+	/**
+	 * Checks if the given String has a video extension. That is, if the String
+	 * ends with "." followed by one of the extensions in
+	 * {@link #videoExtensions}. The comparison is case insensitive
+	 * 
+	 * @param strValue
+	 *            The String value to be checked
+	 * @return True if the value ends with video format extension, false
+	 *         otherwise (or if null)
+	 */
+	public static boolean hasVideoExtension(String strValue) {
+		if (strValue == null)
+			return false;
+		String strValueLowerCase = strValue.toLowerCase();
 		for (String binaryExtension : videoExtensions) {
 			if (strValueLowerCase.endsWith("." + binaryExtension.toLowerCase())) {
 				return true;
 			}
 		}
+		return false;
+	}
+
+	/**
+	 * Checks if the given String has audio extension. That is, if the String
+	 * ends with "." followed by a one of the extensions in (
+	 * {@link #audioExtensions}). The comparison is case insensitive
+	 * 
+	 * @param strValue
+	 *            The String value to be checked
+	 * @return True if the value ends with audio format extension, false
+	 *         otherwise (or if null)
+	 */
+	public static boolean hasAudioExtension(String strValue) {
+		if (strValue == null)
+			return false;
+		String strValueLowerCase = strValue.toLowerCase();
 		for (String binaryExtension : audioExtensions) {
 			if (strValueLowerCase.endsWith("." + binaryExtension.toLowerCase())) {
 				return true;
@@ -377,6 +437,26 @@ public class ReferenceUtils {
 		public boolean checkAndAdd(String binaryReference) {
 			if (binaryReference == null
 					|| !hasBinaryExtension(binaryReference)
+					|| lowerCaseReferences.contains(
+							binaryReference.toLowerCase(), false)) {
+				return false;
+			}
+			lowerCaseReferences.add(binaryReference.toLowerCase());
+			originalReferences.add(binaryReference);
+			return true;
+		}
+
+		/**
+		 * Adds the given String reference to the list if it is not still
+		 * present and it has json extension
+		 * 
+		 * @param binaryReference
+		 *            The Json reference to be added (e.g. "scenes/s1.json")
+		 * @return True if added, false otherwise
+		 */
+		public boolean checkAndAddJson(String binaryReference) {
+			if (binaryReference == null
+					|| !JsonExtension.hasJsonEnd(binaryReference)
 					|| lowerCaseReferences.contains(
 							binaryReference.toLowerCase(), false)) {
 				return false;

--- a/engine/core/src/main/java/es/eucm/ead/engine/utils/ReferenceUtils.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/utils/ReferenceUtils.java
@@ -1,0 +1,394 @@
+/**
+ * eAdventure is a research project of the
+ *    e-UCM research group.
+ *
+ *    Copyright 2005-2014 e-UCM research group.
+ *
+ *    You can access a list of all the contributors to eAdventure at:
+ *          http://e-adventure.e-ucm.es/contributors
+ *
+ *    e-UCM is a research group of the Department of Software Engineering
+ *          and Artificial Intelligence at the Complutense University of Madrid
+ *          (School of Computer Science).
+ *
+ *          CL Profesor Jose Garcia Santesmases 9,
+ *          28040 Madrid (Madrid), Spain.
+ *
+ *          For more info please visit:  <http://e-adventure.e-ucm.es> or
+ *          <http://www.e-ucm.es>
+ *
+ * ****************************************************************************
+ *
+ *  This file is part of eAdventure
+ *
+ *      eAdventure is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU Lesser General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      eAdventure is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public License
+ *      along with eAdventure.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package es.eucm.ead.engine.utils;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.reflect.ClassReflection;
+import com.badlogic.gdx.utils.reflect.Field;
+import com.badlogic.gdx.utils.reflect.ReflectionException;
+import es.eucm.ead.schema.renderers.SpineAnimation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by jtorrente on 04/11/2015.
+ */
+public class ReferenceUtils {
+	public static final Array<String> imageExtensions = new Array<String>(
+			new String[] { "jpg", "jpeg", "png", "gif", "bmp" });
+
+	public static final Array<String> audioExtensions = new Array<String>(
+			new String[] { "mp3", "ogg", "wav" });
+
+	// To detect sound and video extensions
+	private static final Array<String> videoExtensions = new Array<String>(
+			new String[] { "mpg", "mpeg", "avi" });
+
+	/**
+	 * Checks if the given String has a binary extension. That is, if the String
+	 * ends with "." followed by a spine animation file (".json" or ".atlas"),
+	 * an image file extension ({@link #imageExtensions}), an audio file
+	 * extension ({@link #audioExtensions}), or a video file extension (
+	 * {@link #videoExtensions}). The comparison is case insensitive
+	 * 
+	 * @param strValue
+	 *            The String value to be checked
+	 * @return True if the value ends with binary format extension, false
+	 *         otherwise (or if null)
+	 */
+	public static boolean hasBinaryExtension(String strValue) {
+		if (strValue == null)
+			return false;
+		String strValueLowerCase = strValue.toLowerCase();
+		if (strValueLowerCase.endsWith(".json")
+				|| strValueLowerCase.endsWith(".atlas")) {
+			return true;
+		}
+		for (String imageExtension : imageExtensions) {
+			if (strValueLowerCase.endsWith("." + imageExtension.toLowerCase())) {
+				return true;
+			}
+		}
+		for (String binaryExtension : videoExtensions) {
+			if (strValueLowerCase.endsWith("." + binaryExtension.toLowerCase())) {
+				return true;
+			}
+		}
+		for (String binaryExtension : audioExtensions) {
+			if (strValueLowerCase.endsWith("." + binaryExtension.toLowerCase())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Searches for any reference to binary files (images, sounds and videos) in
+	 * the given {@code object}. Search is performed recursively using
+	 * reflection, so it can be used to search for references in any piece of
+	 * the model, entity or component. The method takes into account for
+	 * recursive search maps, libgdx's arrays, and lists. Also fields in any
+	 * superclasses of the object are searched. It is considered a reference to
+	 * a binary file any String field which value ends with any of the supported
+	 * binary formats (see {@link #imageExtensions}, {@link #audioExtensions})
+	 * and {@link #videoExtensions}), either lowercase or uppercase.
+	 * 
+	 * @param object
+	 *            The object to search binary references in.
+	 */
+	public static Array<String> listRefBinaries(Object object) {
+		BinaryReferences binaryPaths = new BinaryReferences();
+		listRefBinaries(object, null, binaryPaths);
+		return binaryPaths.getReferences();
+	}
+
+	private static void listRefBinaries(Object object, Class clazz,
+			BinaryReferences binaryPaths) {
+		if (clazz == null) {
+			clazz = object.getClass();
+		}
+
+		// If the object is from primitive type, do not search
+		if (clazz.isEnum() || clazz == Float.class || clazz == Double.class
+				|| clazz == Boolean.class || clazz == Integer.class
+				|| clazz == Byte.class || clazz == Character.class
+				|| clazz == Long.class || clazz == Short.class) {
+			return;
+		}
+
+		// If the object is a String (leaf)
+		// Leaf: String
+		if (ClassReflection.isAssignableFrom(String.class, clazz)) {
+			String strValue = (String) object;
+			binaryPaths.checkAndAdd(strValue);
+		}
+		// Special case: SpineAnimation does not store extension, and therefore
+		// it needs to be treated differently
+		else if (ClassReflection.isAssignableFrom(SpineAnimation.class, clazz)) {
+			SpineAnimation spineAnimation = (SpineAnimation) object;
+			String baseUri = spineAnimation.getUri();
+			if (baseUri != null) {
+				if (baseUri.toLowerCase().endsWith(".json")) {
+					baseUri = baseUri.substring(0, baseUri.length() - 5);
+				}
+				String pngUri = baseUri + ".png";
+				String jsonUri = baseUri + ".json";
+				String atlasUri = baseUri + ".atlas";
+				// Avoid adding the same reference twice
+				binaryPaths.checkAndAdd(pngUri);
+				binaryPaths.checkAndAdd(jsonUri);
+				binaryPaths.checkAndAdd(atlasUri);
+			}
+		}
+
+		// Iterate through fields
+		for (Field field : ClassReflection.getDeclaredFields(clazz)) {
+			field.setAccessible(true);
+
+			Object value = null;
+			try {
+				value = field.get(object);
+			} catch (ReflectionException e) {
+				e.printStackTrace();
+			}
+			if (value == null) {
+				continue;
+			}
+
+			// Recursive search: array, list, map,
+			if (ClassReflection.isAssignableFrom(Array.class, field.getType())) {
+				Array array = (Array) value;
+				for (Object child : array) {
+					if (child == null) {
+						continue;
+					}
+					listRefBinaries(child, child.getClass(), binaryPaths);
+				}
+			}
+
+			else if (ClassReflection.isAssignableFrom(List.class,
+					field.getType())) {
+				List list = (List) value;
+				for (Object child : list) {
+					if (child == null) {
+						continue;
+					}
+					listRefBinaries(child, child.getClass(), binaryPaths);
+				}
+			}
+
+			else if (ClassReflection.isAssignableFrom(Map.class,
+					field.getType())) {
+				Map map = (Map) value;
+				for (Object child : map.values()) {
+					if (child == null) {
+						continue;
+					}
+					listRefBinaries(child, child.getClass(), binaryPaths);
+				}
+			}
+
+			// Recursive search
+			else {
+				listRefBinaries(value, value.getClass(), binaryPaths);
+			}
+		}
+
+		if (clazz.getSuperclass() != null) {
+			listRefBinaries(object, clazz.getSuperclass(), binaryPaths);
+		}
+	}
+
+	/**
+	 * Utility that searches all string fields in the given object recursively,
+	 * and replaces any occurrences of the oldRef param by the newRef Param
+	 */
+	public static void replaceBinaryRef(Object object, String oldRef,
+			String newRef) {
+		replaceBinaryRef(object, null, oldRef, newRef);
+	}
+
+	private static void replaceBinaryRef(Object object, Class clazz,
+			String oldRef, String newRef) {
+		if (clazz == null) {
+			clazz = object.getClass();
+		}
+
+		// If the object is from primitive type or null, do not search
+		if (object == null || clazz.isEnum() || clazz == Float.class
+				|| clazz == Double.class || clazz == Boolean.class
+				|| clazz == Integer.class || clazz == Byte.class
+				|| clazz == Character.class || clazz == Long.class
+				|| clazz == Short.class) {
+			return;
+		}
+
+		// Special case: SpineAnimation does not store extension, and therefore
+		// it needs to be treated differently
+		else if (ClassReflection.isAssignableFrom(SpineAnimation.class, clazz)) {
+			SpineAnimation spineAnimation = (SpineAnimation) object;
+			String baseUri = spineAnimation.getUri();
+			if (baseUri != null) {
+				baseUri = baseUri.toLowerCase();
+				oldRef = oldRef.toLowerCase();
+				if (baseUri.endsWith(".json")) {
+					baseUri = baseUri.substring(0, baseUri.length() - 5);
+				}
+				if (oldRef.endsWith(".json")) {
+					oldRef = oldRef.substring(0, oldRef.length() - 5);
+				}
+				if (baseUri.equals(oldRef)) {
+					spineAnimation.setUri(newRef);
+				}
+			}
+		}
+
+		// Iterate through fields
+		for (Field field : ClassReflection.getDeclaredFields(clazz)) {
+			field.setAccessible(true);
+
+			Object value = null;
+			try {
+				value = field.get(object);
+			} catch (ReflectionException e) {
+				e.printStackTrace();
+			}
+			if (value == null) {
+				continue;
+			}
+
+			// Recursive search: array, list, map,
+			if (ClassReflection.isAssignableFrom(Array.class, field.getType())) {
+				Array array = (Array) value;
+				for (int i = 0; i < array.size; i++) {
+					Object child = array.get(i);
+					if (child == null) {
+						continue;
+					} else if (child instanceof String) {
+						String strValue = (String) child;
+						if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
+							array.set(i, newRef);
+						}
+					} else {
+						replaceBinaryRef(child, child.getClass(), oldRef,
+								newRef);
+					}
+				}
+			}
+
+			else if (ClassReflection.isAssignableFrom(List.class,
+					field.getType())) {
+				List list = (List) value;
+				for (int i = 0; i < list.size(); i++) {
+					Object child = list.get(i);
+					if (child == null) {
+						continue;
+					} else if (child instanceof String) {
+						String strValue = (String) child;
+						if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
+							list.set(i, newRef);
+						}
+					} else {
+						replaceBinaryRef(child, child.getClass(), oldRef,
+								newRef);
+					}
+				}
+			}
+
+			else if (ClassReflection.isAssignableFrom(Map.class,
+					field.getType())) {
+				Map map = (Map) value;
+				for (Object key : map.keySet()) {
+					Object child = map.get(key);
+					if (child == null) {
+						continue;
+					} else if (child instanceof String) {
+						String strValue = (String) child;
+						if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
+							map.put(key, newRef);
+						}
+					} else {
+						replaceBinaryRef(child, child.getClass(), oldRef,
+								newRef);
+					}
+				}
+			} else if (ClassReflection.isAssignableFrom(String.class,
+					field.getType())) {
+				String strValue = (String) value;
+				// Check if value matches oldRef
+				if (strValue.toLowerCase().equals(oldRef.toLowerCase())) {
+					try {
+						field.set(object, newRef);
+					} catch (ReflectionException e) {
+						Gdx.app.error("Error setting binary ref in field "
+								+ field.getName(), "", e);
+					}
+				}
+			}
+			// Recursive search
+			else {
+				replaceBinaryRef(value, value.getClass(), oldRef, newRef);
+			}
+		}
+
+		if (clazz.getSuperclass() != null) {
+			replaceBinaryRef(object, clazz.getSuperclass(), oldRef, newRef);
+		}
+	}
+
+	/**
+	 * List of unique String references (case-insensitive). Only Strings that
+	 * are not in the list are actually added (case-insensitive comparison)
+	 */
+	private static class BinaryReferences {
+		private Array<String> lowerCaseReferences;
+		private Array<String> originalReferences;
+
+		public BinaryReferences() {
+			lowerCaseReferences = new Array<String>();
+			originalReferences = new Array<String>();
+		}
+
+		/**
+		 * Adds the given String reference to the list if it is not still
+		 * present and it is a binary file
+		 * 
+		 * @param binaryReference
+		 *            The reference to be added (e.g. "image.png" or
+		 *            "sound.wav")
+		 * @return True if added, false otherwise
+		 */
+		public boolean checkAndAdd(String binaryReference) {
+			if (binaryReference == null
+					|| !hasBinaryExtension(binaryReference)
+					|| lowerCaseReferences.contains(
+							binaryReference.toLowerCase(), false)) {
+				return false;
+			}
+			lowerCaseReferences.add(binaryReference.toLowerCase());
+			originalReferences.add(binaryReference);
+			return true;
+		}
+
+		public Array<String> getReferences() {
+			return originalReferences;
+		}
+	}
+
+}

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/PreloadEntityEffectTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/effects/PreloadEntityEffectTest.java
@@ -1,0 +1,349 @@
+/**
+ * eAdventure is a research project of the
+ *    e-UCM research group.
+ *
+ *    Copyright 2005-2014 e-UCM research group.
+ *
+ *    You can access a list of all the contributors to eAdventure at:
+ *          http://e-adventure.e-ucm.es/contributors
+ *
+ *    e-UCM is a research group of the Department of Software Engineering
+ *          and Artificial Intelligence at the Complutense University of Madrid
+ *          (School of Computer Science).
+ *
+ *          CL Profesor Jose Garcia Santesmases 9,
+ *          28040 Madrid (Madrid), Spain.
+ *
+ *          For more info please visit:  <http://e-adventure.e-ucm.es> or
+ *          <http://www.e-ucm.es>
+ *
+ * ****************************************************************************
+ *
+ *  This file is part of eAdventure
+ *
+ *      eAdventure is free software: you can redistribute it and/or modify
+ *      it under the terms of the GNU Lesser General Public License as published by
+ *      the Free Software Foundation, either version 3 of the License, or
+ *      (at your option) any later version.
+ *
+ *      eAdventure is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public License
+ *      along with eAdventure.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package es.eucm.ead.engine.tests.systems.effects;
+
+import com.badlogic.gdx.Files;
+import com.badlogic.gdx.assets.AssetDescriptor;
+import com.badlogic.gdx.assets.AssetLoaderParameters;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.assets.loaders.SoundLoader;
+import com.badlogic.gdx.audio.Sound;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.utils.Array;
+import es.eucm.ead.engine.assets.JsonLoader;
+import es.eucm.ead.engine.assets.ScaledTexture;
+import es.eucm.ead.engine.assets.loaders.ScaledTextureLoader;
+import es.eucm.ead.engine.entities.EngineEntity;
+import es.eucm.ead.engine.mock.MockFileHandle;
+import es.eucm.ead.engine.mock.schema.MockEffect;
+import es.eucm.ead.engine.processors.behaviors.BehaviorsProcessor;
+import es.eucm.ead.engine.processors.renderers.FramesProcessor;
+import es.eucm.ead.engine.processors.renderers.ImageProcessor;
+import es.eucm.ead.engine.systems.effects.PlaySoundExecutor;
+import es.eucm.ead.engine.systems.effects.PreloadEntityExecutor;
+import es.eucm.ead.schema.components.behaviors.Behavior;
+import es.eucm.ead.schema.effects.PlaySound;
+import es.eucm.ead.schema.effects.PreloadEntity;
+import es.eucm.ead.schema.entities.ModelEntity;
+import es.eucm.ead.schema.renderers.Frames;
+import es.eucm.ead.schema.renderers.Image;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Created by jtorrente on 04/11/2015.
+ */
+public class PreloadEntityEffectTest extends EffectTest {
+
+	public static final String ENTITY_URI = "entity1.json";
+	public static final String IMAGE_01 = "image1.png";
+	public static final String IMAGE_02 = "imgs/image2.jpeg";
+	public static final String IMAGE_03 = "imgs/image3.JPG";
+	public static final String SOUND_01 = "sound1.wav";
+	public static final String SOUND_02 = "sounds/path/sound2.MP3";
+
+	private boolean executed = false;
+
+	@Before
+	public void setup() {
+		componentLoader.registerComponentProcessor(Behavior.class,
+				new BehaviorsProcessor(gameLoop));
+		componentLoader.registerComponentProcessor(Frames.class,
+				new FramesProcessor(gameLoop, gameAssets, componentLoader));
+		componentLoader.registerComponentProcessor(Image.class,
+				new ImageProcessor(gameLoop, gameAssets));
+		effectsSystem.registerEffectExecutor(PlaySound.class,
+				new PlaySoundExecutor(effectsSystem));
+		effectsSystem.registerEffectExecutor(PreloadEntity.class,
+				new PreloadEntityExecutor(entitiesLoader, effectsSystem,
+						variablesManager, gameAssets));
+		ModelEntity entity = entity((ModelEntity) null, 0, 0)
+				.frames(0.1F, IMAGE_01, IMAGE_02, IMAGE_03).initBehavior()
+				.playSound(SOUND_01).playSound(SOUND_02).getLastEntity();
+		gameAssets
+				.setLoader(Object.class, new ModelEntityLoaderForTest(entity));
+		gameAssets.setLoader(ScaledTexture.class, new TextureLoaderForTest());
+		gameAssets.setLoader(Sound.class, new SoundLoaderForTest());
+	}
+
+	@Test
+	public void test() {
+		ModelEntity firstEntity = entity((ModelEntity) null, 0, 0)
+				.initBehavior()
+				.preloadEntity(ENTITY_URI,
+						new MockEffect(new MockEffect.MockEffectListener() {
+							@Override
+							public void executed() {
+								executed = true;
+							}
+						})).getLastEntity();
+
+		EngineEntity firstEngineEntity = entitiesLoader
+				.toEngineEntity(firstEntity);
+		gameLoop.addEntity(firstEngineEntity);
+		update();
+		update();
+		update();
+		assertFalse(executed);
+		assertTrue(gameAssets.isLoaded(ENTITY_URI));
+		update();
+		assertTrue(gameAssets.isLoaded(IMAGE_01 + ".tex"));
+		assertTrue(gameAssets.isLoaded(IMAGE_02 + ".tex"));
+		assertTrue(gameAssets.isLoaded(IMAGE_03 + ".tex"));
+		assertTrue(gameAssets.isLoaded(SOUND_01));
+		assertTrue(gameAssets.isLoaded(SOUND_02));
+		assertTrue(executed);
+	}
+
+	public void update() {
+		gameAssets.update();
+		super.update(0);
+	}
+
+	private static class ModelEntityLoaderForTest extends JsonLoader<Object> {
+
+		public ModelEntityLoaderForTest(ModelEntity modelEntity) {
+			super(null, Object.class);
+			object = modelEntity;
+		}
+
+		@Override
+		public FileHandle resolve(String fileName) {
+			return new MockFileHandle("", Files.FileType.Absolute);
+		}
+
+		@Override
+		public void loadAsync(AssetManager manager, String fileName,
+				FileHandle file, AssetLoaderParameters<Object> parameter) {
+		}
+	}
+
+	private static class TextureLoaderForTest extends ScaledTextureLoader {
+
+		private static final byte[] IMAGE_BYTES = { -119, 80, 78, 71, 13, 10,
+				26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8,
+				2, 0, 0, 0, -112, 119, 83, -34, 0, 0, 0, 9, 112, 72, 89, 115,
+				0, 0, 46, 35, 0, 0, 46, 35, 1, 120, -91, 63, 118, 0, 0, 1, 54,
+				105, 67, 67, 80, 80, 104, 111, 116, 111, 115, 104, 111, 112,
+				32, 73, 67, 67, 32, 112, 114, 111, 102, 105, 108, 101, 0, 0,
+				120, -38, -83, -114, -79, 74, -61, 80, 20, 64, -49, -117, -94,
+				-30, 80, 43, 4, 113, 112, 120, -109, 40, 40, -74, -22, 96, -58,
+				-92, 45, 69, 16, -84, -43, 33, -55, -42, -92, -95, 74, 105, 18,
+				94, 94, -43, 126, -124, -93, 91, 7, 23, 119, -65, -64, -55, 81,
+				112, 80, -4, 2, -1, 64, 113, -22, -32, 16, 33, -125, -125, 8,
+				-98, -23, -36, -61, -27, 114, -63, -88, -40, 117, -89, 97,
+				-108, 97, 16, 107, -43, 110, 58, -46, -11, 124, 57, -5, -60,
+				12, 83, 0, -48, 9, -77, -44, 110, -75, 14, 0, -30, 36, -114,
+				-8, -63, -25, 43, 2, -32, 121, -45, -82, 59, 13, -2, -58, 124,
+				-104, 42, 13, 76, -128, -19, 110, -108, -123, 32, 42, 64, -1,
+				66, -89, 26, -60, 24, 48, -125, 126, -86, 65, -36, 1, -90, 58,
+				105, -41, 64, 60, 0, -91, 94, -18, 47, 64, 41, -56, -3, 13, 40,
+				41, -41, -13, 65, 124, 0, 102, -49, -11, 124, 48, -26, 0, 51,
+				-56, 125, 5, 48, 117, 116, -87, 1, 106, 73, 58, 82, 103, -67,
+				83, 45, -85, -106, 101, 73, -69, -101, 4, -111, 60, 30, 101,
+				58, 26, 100, 114, 63, 14, 19, -107, 38, -86, -93, -93, 46,
+				-112, -1, 7, -64, 98, -66, -40, 110, 58, 114, -83, 106, 89,
+				123, -21, -4, 51, -82, -25, -53, -36, -34, -113, 16, -128, 88,
+				122, 44, 90, 65, 56, 84, -25, -33, 42, -116, -99, -33, -25,
+				-30, -58, 120, 25, 14, 111, 97, 122, 82, -76, -35, 43, -72,
+				-39, -128, -123, -21, -94, -83, 86, -95, -68, 5, -9, -29, 47,
+				-64, -58, 79, -3, -24, 90, 79, 98, 0, 0, 0, 32, 99, 72, 82, 77,
+				0, 0, 122, 37, 0, 0, -128, -125, 0, 0, -7, -1, 0, 0, -128, -24,
+				0, 0, 82, 8, 0, 1, 21, 88, 0, 0, 58, -105, 0, 0, 23, 111, -41,
+				90, 31, -112, 0, 0, 0, 18, 73, 68, 65, 84, 120, -38, 98, 120,
+				-38, -50, 4, 0, 0, 0, -1, -1, 3, 0, 3, -61, 1, 111, 67, -8, 61,
+				30, 0, 0, 0, 0, 73, 69, 78, 68, -82, 66, 96, -126 };
+		private static final ScaledTexture TEXTURE = buildTexture();
+
+		private static ScaledTexture buildTexture() {
+			Pixmap pixmap = new Pixmap(IMAGE_BYTES, 0, IMAGE_BYTES.length);
+			Texture texture = new Texture(pixmap);
+			ScaledTexture scaledTexture = new ScaledTexture(texture, 1.0F);
+			return scaledTexture;
+		}
+
+		public TextureLoaderForTest() {
+			super(null, null);
+		}
+
+		@Override
+		public FileHandle resolve(String fileName) {
+			return new MockFileHandle("", Files.FileType.Absolute);
+		}
+
+		@Override
+		public ScaledTexture loadSync(AssetManager manager, String fileName,
+				FileHandle file, AssetLoaderParameters<ScaledTexture> parameter) {
+			return TEXTURE;
+		}
+
+		@Override
+		public Array<AssetDescriptor> getDependencies(String fileName,
+				FileHandle file, AssetLoaderParameters<ScaledTexture> parameter) {
+			return null;
+		}
+	}
+
+	private static class SoundLoaderForTest extends SoundLoader {
+
+		public SoundLoaderForTest() {
+			super(null);
+		}
+
+		@Override
+		public FileHandle resolve(String fileName) {
+			return new MockFileHandle("", Files.FileType.Absolute) {
+				public long length() {
+					return 1;
+				}
+			};
+		}
+
+		@Override
+		public void loadAsync(AssetManager manager, String fileName,
+				FileHandle file, SoundParameter parameter) {
+		}
+
+		@Override
+		public Sound loadSync(AssetManager manager, String fileName,
+				FileHandle file, SoundParameter parameter) {
+			Sound sound = new Sound() {
+				@Override
+				public long play() {
+					return 0;
+				}
+
+				@Override
+				public long play(float volume) {
+					return 0;
+				}
+
+				@Override
+				public long play(float volume, float pitch, float pan) {
+					return 0;
+				}
+
+				@Override
+				public long loop() {
+					return 0;
+				}
+
+				@Override
+				public long loop(float volume) {
+					return 0;
+				}
+
+				@Override
+				public long loop(float volume, float pitch, float pan) {
+					return 0;
+				}
+
+				@Override
+				public void stop() {
+
+				}
+
+				@Override
+				public void pause() {
+
+				}
+
+				@Override
+				public void resume() {
+
+				}
+
+				@Override
+				public void dispose() {
+
+				}
+
+				@Override
+				public void stop(long soundId) {
+
+				}
+
+				@Override
+				public void pause(long soundId) {
+
+				}
+
+				@Override
+				public void resume(long soundId) {
+
+				}
+
+				@Override
+				public void setLooping(long soundId, boolean looping) {
+
+				}
+
+				@Override
+				public void setPitch(long soundId, float pitch) {
+
+				}
+
+				@Override
+				public void setVolume(long soundId, float volume) {
+
+				}
+
+				@Override
+				public void setPan(long soundId, float pan, float volume) {
+
+				}
+
+				@Override
+				public void setPriority(long soundId, int priority) {
+
+				}
+			};
+			return sound;
+		}
+
+		@Override
+		public Array<AssetDescriptor> getDependencies(String fileName,
+				FileHandle file, SoundParameter parameter) {
+			return null;
+		}
+	}
+}

--- a/engine/core/src/test/java/es/eucm/ead/engine/utils/ReferenceUtilsTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/utils/ReferenceUtilsTest.java
@@ -34,7 +34,7 @@
  *      You should have received a copy of the GNU Lesser General Public License
  *      along with eAdventure.  If not, see <http://www.gnu.org/licenses/>.
  */
-package es.eucm.ead.editor.utils;
+package es.eucm.ead.engine.utils;
 
 import com.badlogic.gdx.utils.Array;
 import es.eucm.ead.schema.renderers.SpineAnimation;
@@ -49,10 +49,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Created by jtorrente on 26/11/14.
+ * Created by jtorrente on 04/11/2015.
  */
-public class ProjectUtilsTest {
-
+public class ReferenceUtilsTest {
 	private static Array<String> buildUris() {
 		return new Array<String>(new String[] { "images/image1.png",
 				"images/image2.JPEG", "videos/video1.mpg", "video2.avi",
@@ -62,13 +61,13 @@ public class ProjectUtilsTest {
 
 	@Test
 	/**
-	 * Tests {@link es.eucm.ead.editor.utils.ProjectUtils#listRefBinaries(Object)}
+	 * Tests {@link es.eucm.ead.engine.utils.ReferenceUtils#listRefBinaries(Object)}
 	 */
 	public void testBinaryReferencesSearch() {
 		Array<String> uris = buildUris();
 		// Create a simple object
 		BinRefContainer binRefContainer = new BinRefContainer(uris);
-		Array<String> binaryReferences = ProjectUtils
+		Array<String> binaryReferences = ReferenceUtils
 				.listRefBinaries(binRefContainer);
 		for (int i = 0; i < uris.size; i++) {
 			String current = uris.get(i);
@@ -93,24 +92,24 @@ public class ProjectUtilsTest {
 
 	@Test
 	/**
-	 * Tests {@link es.eucm.ead.editor.utils.ProjectUtils#replaceBinaryRef(Object, String, String)}
+	 * Tests {@link es.eucm.ead.engine.utils.ReferenceUtils#replaceBinaryRef(Object, String, String)}
 	 */
 	public void testReplaceBinaryRef() {
 		Array<String> uris = buildUris();
 		// Create a simple object
 		BinRefContainer binRefContainer = new BinRefContainer(uris);
-		ProjectUtils
-				.replaceBinaryRef(binRefContainer, "A test", "Another test");
+		ReferenceUtils.replaceBinaryRef(binRefContainer, "A test",
+				"Another test");
 		assertEquals(binRefContainer.notAnUri, "Another test");
 		String str = "simple test";
-		ProjectUtils.replaceBinaryRef(binRefContainer, uris.get(2), str);
-		ProjectUtils.replaceBinaryRef(binRefContainer, uris.get(3), str);
-		ProjectUtils.replaceBinaryRef(binRefContainer, uris.get(4), str);
-		ProjectUtils.replaceBinaryRef(binRefContainer, uris.get(5), str);
-		ProjectUtils.replaceBinaryRef(binRefContainer, uris.get(6), str);
-		ProjectUtils
-				.replaceBinaryRef(binRefContainer, uris.get(8), "skeleton3");
-		ProjectUtils.replaceBinaryRef(binRefContainer, "skeleton3.json",
+		ReferenceUtils.replaceBinaryRef(binRefContainer, uris.get(2), str);
+		ReferenceUtils.replaceBinaryRef(binRefContainer, uris.get(3), str);
+		ReferenceUtils.replaceBinaryRef(binRefContainer, uris.get(4), str);
+		ReferenceUtils.replaceBinaryRef(binRefContainer, uris.get(5), str);
+		ReferenceUtils.replaceBinaryRef(binRefContainer, uris.get(6), str);
+		ReferenceUtils.replaceBinaryRef(binRefContainer, uris.get(8),
+				"skeleton3");
+		ReferenceUtils.replaceBinaryRef(binRefContainer, "skeleton3.json",
 				"skeleton2");
 		assertEquals(binRefContainer.refHolder.uri, str);
 		assertEquals(binRefContainer.list.get(0).uri, str);
@@ -167,4 +166,5 @@ public class ProjectUtilsTest {
 			this.uri = uri;
 		}
 	}
+
 }

--- a/engine/core/src/test/java/es/eucm/ead/engine/utils/ReferenceUtilsTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/utils/ReferenceUtilsTest.java
@@ -59,6 +59,11 @@ public class ReferenceUtilsTest {
 				"icons/icon2.jpg", "skeleton" });
 	}
 
+	private static Array<String> buildEntityUris() {
+		return new Array<String>(new String[] { "scenes/scene1.JSON",
+				"scenes/s2.json", "reusable1.jsn" });
+	}
+
 	@Test
 	/**
 	 * Tests {@link es.eucm.ead.engine.utils.ReferenceUtils#listRefBinaries(Object)}
@@ -141,16 +146,17 @@ public class ReferenceUtilsTest {
 		private SpineAnimation animation;
 
 		public BinRefContainer(Array<String> uris) {
-			uriRef2 = uris.get(1);
-			refHolder = new SimpleRefHolder(uris.get(2));
-			list.add(new SimpleRefHolder(uris.get(3)));
-			list.add(new SimpleRefHolder(uris.get(4)));
-			array.add(new SimpleRefHolder(uris.get(5)));
-			array.add(new SimpleRefHolder(uris.get(0)));
-			uriMap.put("uri1", uris.get(6));
-			uriMap.put("uri2", uris.get(7));
+			int s = uris.size;
+			uriRef2 = uris.get(1 % s);
+			refHolder = new SimpleRefHolder(uris.get(2 % s));
+			list.add(new SimpleRefHolder(uris.get(3 % s)));
+			list.add(new SimpleRefHolder(uris.get(4 % s)));
+			array.add(new SimpleRefHolder(uris.get(5 % s)));
+			array.add(new SimpleRefHolder(uris.get(0 % s)));
+			uriMap.put("uri1", uris.get(6 % s));
+			uriMap.put("uri2", uris.get(7 % s));
 			animation = new SpineAnimation();
-			animation.setUri(uris.get(8));
+			animation.setUri(uris.get(8 % s));
 		}
 	}
 

--- a/repo-builder/src/main/java/es/eucm/ead/repobuilder/RepoLibraryBuilder.java
+++ b/repo-builder/src/main/java/es/eucm/ead/repobuilder/RepoLibraryBuilder.java
@@ -47,6 +47,7 @@ import es.eucm.ead.editor.exporter.ExportCallback;
 import es.eucm.ead.editor.exporter.Exporter;
 import es.eucm.ead.editor.utils.ProjectUtils;
 import es.eucm.ead.engine.demobuilder.img.ImgUtils;
+import es.eucm.ead.engine.utils.ReferenceUtils;
 import es.eucm.ead.schema.components.ModelComponent;
 import es.eucm.ead.schema.components.behaviors.Behavior;
 import es.eucm.ead.schema.components.behaviors.events.Touch;
@@ -478,7 +479,7 @@ public abstract class RepoLibraryBuilder extends ExecutableDemoBuilder {
 	private FileHandle exportElement(ModelEntity modelEntity,
 			FileHandle outputFH) {
 		// Make a list of all binaries referenced by this modelEntity
-		Array<String> binaryPaths = ProjectUtils.listRefBinaries(modelEntity);
+		Array<String> binaryPaths = ReferenceUtils.listRefBinaries(modelEntity);
 		// Copy all binaries to a temp folder
 		FileHandle tempFolder = FileHandle.tempDirectory("modelentity");
 		tempFolder.mkdirs();


### PR DESCRIPTION
This effect is a simple (but effective) way to improve scene transitioning experience. In essence, it loads (in the background) all images and sounds in a particular entity. This way, it is possible to anticipate loading of a particular heavy scene before it is actually needed.
