### PR TITLE
Goscene bug + Visibility flickering

### DIFF
--- a/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/DefaultEngineInitializer.java
@@ -318,7 +318,7 @@ public class DefaultEngineInitializer implements EngineInitializer {
 		componentLoader.registerComponentProcessor(PersistentGameState.class,
 				new PersistentGameStateProcessor(gameLoop));
 		componentLoader.registerComponentProcessor(Visibility.class,
-				new VisibilityProcessor(gameLoop));
+				new VisibilityProcessor(gameLoop, variablesManager));
 		componentLoader.registerComponentProcessor(Touchability.class,
 				new TouchabilityProcessor(gameLoop));
 		componentLoader.registerComponentProcessor(PathBoundary.class,

--- a/engine/core/src/main/java/es/eucm/ead/engine/components/VisibilityComponent.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/components/VisibilityComponent.java
@@ -36,9 +36,42 @@
  */
 package es.eucm.ead.engine.components;
 
+import es.eucm.ead.engine.entities.EngineEntity;
+import es.eucm.ead.engine.variables.VariablesManager;
+
 /**
  * Engine equivalent for {@link es.eucm.ead.schema.components.Visibility}
  * Created by Javier Torrente on 17/04/14.
  */
 public class VisibilityComponent extends ConditionedComponent {
+
+	private VariablesManager variablesManager;
+
+	public void setVariablesManager(VariablesManager variablesManager) {
+		this.variablesManager = variablesManager;
+	}
+
+	/*
+	 * Method init() is overriden to make sure that entity's visibility is
+	 * updated BEFORE it is attached to the gameView. Otherwise a nasty
+	 * "flickering" effect happens when visibility is false, as the entity is
+	 * added and then hidden, leaving it visible for a fraction of a second
+	 */
+	@Override
+	public void init() {
+		update();
+	}
+
+	/**
+	 * Evaluates condition and applies its changes to the parent entity's group
+	 */
+	public void update() {
+		if (parent instanceof EngineEntity) {
+			boolean condition = variablesManager.evaluateCondition(
+					getCondition(), true);
+			// Change the visibility
+			EngineEntity engineEntity = (EngineEntity) parent;
+			engineEntity.getGroup().setVisible(condition);
+		}
+	}
 }

--- a/engine/core/src/main/java/es/eucm/ead/engine/processors/VisibilityProcessor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/processors/VisibilityProcessor.java
@@ -39,6 +39,8 @@ package es.eucm.ead.engine.processors;
 import com.badlogic.ashley.core.Component;
 import es.eucm.ead.engine.GameLoop;
 import es.eucm.ead.engine.components.VisibilityComponent;
+import es.eucm.ead.engine.systems.VisibilitySystem;
+import es.eucm.ead.engine.variables.VariablesManager;
 import es.eucm.ead.schema.components.Visibility;
 
 /**
@@ -46,14 +48,20 @@ import es.eucm.ead.schema.components.Visibility;
  * engine components. Created by Javier Torrente on 17/04/14.
  */
 public class VisibilityProcessor extends ComponentProcessor<Visibility> {
-	public VisibilityProcessor(GameLoop engine) {
+
+	private VariablesManager variablesManager;
+
+	public VisibilityProcessor(GameLoop engine,
+			VariablesManager variablesManager) {
 		super(engine);
+		this.variablesManager = variablesManager;
 	}
 
 	@Override
 	public Component getComponent(Visibility component) {
 		VisibilityComponent visibilityComponent = gameLoop
 				.createComponent(VisibilityComponent.class);
+		visibilityComponent.setVariablesManager(variablesManager);
 		visibilityComponent.setCondition(component.getCondition());
 		return visibilityComponent;
 	}

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/VisibilitySystem.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/VisibilitySystem.java
@@ -40,7 +40,6 @@ import com.badlogic.ashley.core.Entity;
 import com.badlogic.ashley.core.Family;
 import es.eucm.ead.engine.GameLoop;
 import es.eucm.ead.engine.components.VisibilityComponent;
-import es.eucm.ead.engine.entities.EngineEntity;
 import es.eucm.ead.engine.variables.VariablesManager;
 
 /**
@@ -60,13 +59,6 @@ public class VisibilitySystem extends ConditionalSystem {
 	public void doProcessEntity(Entity entity, float deltaTime) {
 		VisibilityComponent visibilityComponent = entity
 				.getComponent(VisibilityComponent.class);
-
-		if (entity instanceof EngineEntity) {
-			boolean condition = evaluateCondition(visibilityComponent
-					.getCondition());
-			// Change the visibility
-			EngineEntity engineEntity = (EngineEntity) entity;
-			engineEntity.getGroup().setVisible(condition);
-		}
+		visibilityComponent.update();
 	}
 }

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/GoSceneExecutor.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/effects/GoSceneExecutor.java
@@ -115,7 +115,7 @@ public class GoSceneExecutor extends EffectExecutor<GoScene> implements
 						false));
 		gameLoop.setPlaying(effect.isUpdateGameLoop());
 
-		if (sceneLayer.getChildren().size == 1) {
+		if (sceneLayer.getChildren().size >= 1) {
 			Actor currentScene = sceneLayer.getChildren().get(0);
 			transitionManager.setCurrentScene(
 					((Stage) Gdx.input.getInputProcessor()).getBatch(),

--- a/engine/core/src/main/java/es/eucm/ead/engine/systems/gamestatepersistence/PersistentGameStateSystem.java
+++ b/engine/core/src/main/java/es/eucm/ead/engine/systems/gamestatepersistence/PersistentGameStateSystem.java
@@ -184,7 +184,7 @@ public class PersistentGameStateSystem extends IteratingSystem {
 	}
 
 	/**
-	 * Reads persistent game state from disk. This inlcudes persistent
+	 * Reads persistent game state from disk. This includes persistent
 	 * variables, which are read and their value updated accordingly. If
 	 * variables read from disk have not been yet initialized in global context,
 	 * it is done so.

--- a/engine/core/src/test/java/es/eucm/ead/engine/AccessorTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/AccessorTest.java
@@ -46,6 +46,7 @@ import com.badlogic.gdx.utils.ObjectMap;
 import es.eucm.ead.engine.components.VisibilityComponent;
 import es.eucm.ead.engine.processors.TagsProcessor;
 import es.eucm.ead.engine.processors.VisibilityProcessor;
+import es.eucm.ead.engine.systems.VisibilitySystem;
 import es.eucm.ead.schema.components.ModelComponent;
 import es.eucm.ead.schema.components.Tags;
 import es.eucm.ead.schema.components.Visibility;
@@ -181,7 +182,7 @@ public class AccessorTest extends EngineTest {
 		Map<String, Object> rootObjects = getRootObjects();
 
 		componentLoader.registerComponentProcessor(Visibility.class,
-				new VisibilityProcessor(gameLoop));
+				new VisibilityProcessor(gameLoop, variablesManager));
 		componentLoader.registerComponentProcessor(Tags.class,
 				new TagsProcessor(gameLoop));
 

--- a/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/VisibilityTest.java
+++ b/engine/core/src/test/java/es/eucm/ead/engine/tests/systems/VisibilityTest.java
@@ -68,9 +68,11 @@ public class VisibilityTest extends EngineTest {
 	@Before
 	public void setUp() {
 		super.setUp();
-		gameLoop.addSystem(new VisibilitySystem(gameLoop, variablesManager));
+		VisibilitySystem visibilitySystem = new VisibilitySystem(gameLoop,
+				variablesManager);
+		gameLoop.addSystem(visibilitySystem);
 		componentLoader.registerComponentProcessor(Visibility.class,
-				new VisibilityProcessor(gameLoop));
+				new VisibilityProcessor(gameLoop, variablesManager));
 
 		// Add a variable that will be referenced in the expressions of this
 		// test
@@ -92,10 +94,9 @@ public class VisibilityTest extends EngineTest {
 				.all(VisibilityComponent.class).get());
 		EngineEntity engineEntity = (EngineEntity) entityIntMap.iterator()
 				.next();
-		assertTrue(engineEntity.getGroup().isVisible());
+		assertFalse(engineEntity.getGroup().isVisible());
 
 		gameLoop.update(1);
-		assertFalse(engineEntity.getGroup().isVisible());
 
 		variablesManager.setVarToExpression(variableDef, "i1");
 		gameLoop.update(1);


### PR DESCRIPTION
Solves a couple of issues:
1) An exception is thrown in GoSceneExecutor if an entity has been added to SCENE_LAYER via effect
2) Entities loaded with visibility component = false are shown for a fraction of a second.